### PR TITLE
Add collaborator picker for issue assignees

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -224,6 +224,38 @@ pub async fn github_update_repo(
     db::update_repo(&db, &repo)
 }
 
+// ── Collaborator Commands ────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn github_list_collaborators(
+    state: tauri::State<'_, AppState>,
+    owner: String,
+    name: String,
+) -> Result<Vec<GitHubUser>, String> {
+    let token = get_token(&state)?;
+    let client = &state.http_client;
+
+    let resp = client
+        .get(format!(
+            "{GITHUB_API}/repos/{owner}/{name}/collaborators?per_page=100"
+        ))
+        .headers(github_headers(&token))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch collaborators: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("GitHub API error {}", resp.status()));
+    }
+
+    let users: Vec<GitHubUser> = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse collaborators: {e}"))?;
+
+    Ok(users)
+}
+
 // ── Issue Commands ──────────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,8 @@ pub fn run() {
             github::github_remove_repo,
             github::github_get_repos,
             github::github_update_repo,
+            // GitHub collaborators
+            github::github_list_collaborators,
             // GitHub issues
             github::github_fetch_issues,
             github::github_create_issue,

--- a/src/lib/components/NewIssueDialog.svelte
+++ b/src/lib/components/NewIssueDialog.svelte
@@ -4,30 +4,78 @@
 	import { repos, selectedRepoId } from '$lib/stores/repos';
 	import { currentUser } from '$lib/stores/auth';
 	import * as backend from '$lib/stores/backend';
-	import { X } from 'lucide-svelte';
+	import type { GitHubUser } from '$lib/types';
+	import { X, ChevronDown, Check, Loader2 } from 'lucide-svelte';
 
 	let title = $state('');
 	let body = $state('');
-	let assignee = $state('');
+	let selectedAssignee = $state<GitHubUser | null>(null);
+	let collaborators = $state<GitHubUser[]>([]);
+	let loadingCollaborators = $state(false);
+	let dropdownOpen = $state(false);
 
 	let selectedRepo = $derived($repos.find((r) => r.id === $selectedRepoId));
 
-	// Set default assignee from current user
+	let isCurrentUser = $derived(
+		selectedAssignee !== null &&
+			$currentUser !== null &&
+			selectedAssignee.login === $currentUser.login
+	);
+
+	let createAndStartDisabled = $derived(
+		!title.trim() || !selectedRepo || !isCurrentUser
+	);
+
+	// Fetch collaborators and set default assignee when dialog opens
 	$effect(() => {
-		if ($showNewIssueDialog && $currentUser) {
-			assignee = $currentUser.login;
+		if ($showNewIssueDialog && selectedRepo) {
+			loadingCollaborators = true;
+			backend
+				.listCollaborators(selectedRepo.owner, selectedRepo.name)
+				.then((users) => {
+					collaborators = users;
+					// Default to current user if they are in the list
+					if ($currentUser) {
+						const match = users.find((u) => u.login === $currentUser!.login);
+						selectedAssignee = match ?? $currentUser;
+					}
+				})
+				.catch(() => {
+					collaborators = [];
+				})
+				.finally(() => {
+					loadingCollaborators = false;
+				});
 		}
 	});
 
 	function resetForm() {
 		title = '';
 		body = '';
-		assignee = $currentUser?.login ?? '';
+		selectedAssignee = $currentUser ?? null;
+		collaborators = [];
+		dropdownOpen = false;
 	}
 
 	function handleClose() {
 		showNewIssueDialog.set(false);
 		resetForm();
+	}
+
+	function selectAssignee(user: GitHubUser | null) {
+		selectedAssignee = user;
+		dropdownOpen = false;
+	}
+
+	function handleDropdownToggle() {
+		dropdownOpen = !dropdownOpen;
+	}
+
+	function handleClickOutside(event: MouseEvent) {
+		const target = event.target as HTMLElement;
+		if (!target.closest('.assignee-dropdown')) {
+			dropdownOpen = false;
+		}
 	}
 
 	async function handleCreate() {
@@ -43,17 +91,19 @@
 	}
 
 	async function handleCreateAndStart() {
-		if (!title.trim() || !selectedRepo) return;
+		if (!title.trim() || !selectedRepo || !selectedAssignee) return;
 		await backend.createIssue(
 			selectedRepo.owner,
 			selectedRepo.name,
 			title.trim(),
 			body.trim(),
-			assignee.trim() || null
+			selectedAssignee.login
 		);
 		handleClose();
 	}
 </script>
+
+<svelte:window onclick={handleClickOutside} />
 
 <Dialog.Root
 	open={$showNewIssueDialog}
@@ -104,13 +154,73 @@
 					</div>
 
 					<div class="space-y-1.5">
-						<label for="issue-assignee" class="text-sm font-medium text-foreground">Assignee</label>
-						<input
-							id="issue-assignee"
-							class="w-full bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring"
-							placeholder="GitHub username"
-							bind:value={assignee}
-						/>
+						<span id="assignee-label" class="text-sm font-medium text-foreground">Assignee</span>
+						<div class="assignee-dropdown relative">
+							<button
+								type="button"
+								aria-labelledby="assignee-label"
+								class="w-full bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring flex items-center justify-between gap-2"
+								onclick={handleDropdownToggle}
+							>
+								{#if loadingCollaborators}
+									<span class="flex items-center gap-2 text-muted-foreground">
+										<Loader2 class="h-4 w-4 animate-spin" />
+										Loading...
+									</span>
+								{:else if selectedAssignee}
+									<span class="flex items-center gap-2">
+										<img
+											src={selectedAssignee.avatar_url}
+											alt={selectedAssignee.login}
+											class="h-5 w-5 rounded-full"
+										/>
+										{selectedAssignee.login}
+									</span>
+								{:else}
+									<span class="text-muted-foreground">Unassigned</span>
+								{/if}
+								<ChevronDown class="h-4 w-4 text-muted-foreground shrink-0" />
+							</button>
+
+							{#if dropdownOpen}
+								<div
+									class="absolute left-0 right-0 top-full mt-1 z-10 bg-popover border border-border rounded-md shadow-lg max-h-48 overflow-y-auto"
+								>
+									<button
+										type="button"
+										class="w-full px-3 py-2 text-sm text-left flex items-center gap-2 hover:bg-muted transition-colors"
+										onclick={() => selectAssignee(null)}
+									>
+										<span class="h-5 w-5 flex items-center justify-center">
+											{#if selectedAssignee === null}
+												<Check class="h-3.5 w-3.5 text-foreground" />
+											{/if}
+										</span>
+										<span class="text-muted-foreground">Unassigned</span>
+									</button>
+
+									{#each collaborators as collaborator (collaborator.id)}
+										<button
+											type="button"
+											class="w-full px-3 py-2 text-sm text-left flex items-center gap-2 hover:bg-muted transition-colors"
+											onclick={() => selectAssignee(collaborator)}
+										>
+											<span class="h-5 w-5 flex items-center justify-center">
+												{#if selectedAssignee?.login === collaborator.login}
+													<Check class="h-3.5 w-3.5 text-foreground" />
+												{/if}
+											</span>
+											<img
+												src={collaborator.avatar_url}
+												alt={collaborator.login}
+												class="h-5 w-5 rounded-full"
+											/>
+											<span class="text-foreground">{collaborator.login}</span>
+										</button>
+									{/each}
+								</div>
+							{/if}
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -132,7 +242,7 @@
 				<button
 					class="px-3 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
 					onclick={handleCreateAndStart}
-					disabled={!title.trim() || !selectedRepo}
+					disabled={createAndStartDisabled}
 				>
 					Create & Start
 				</button>

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -101,6 +101,11 @@ export async function getRepos(): Promise<RepoConfig[]> {
 	return invoke('github_get_repos');
 }
 
+// Collaborators
+export async function listCollaborators(owner: string, name: string): Promise<GitHubUser[]> {
+	return invoke('github_list_collaborators', { owner, name });
+}
+
 // Issues
 export async function fetchIssues(owner: string, name: string): Promise<Issue[]> {
 	return invoke('github_fetch_issues', { owner, name });


### PR DESCRIPTION
## Summary
- Replaces the free-text assignee input in the new issue dialog with a dropdown that fetches actual repo collaborators from the GitHub API (`GET /repos/{owner}/{name}/collaborators`)
- Shows each collaborator's avatar and login in the picker, with an "Unassigned" option
- Disables the "Create & Start" button when the selected assignee is not the current user

## Test plan
- [ ] Open the new issue dialog and verify collaborators load in the assignee dropdown
- [ ] Confirm the current user is selected by default
- [ ] Select a different collaborator and verify "Create & Start" becomes disabled
- [ ] Select "Unassigned" and verify "Create & Start" is disabled
- [ ] Re-select yourself and verify "Create & Start" re-enables
- [ ] Create an issue and confirm the assignee is set correctly on GitHub