### PR TITLE
feat: add dev script with port cleanup

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_pid=""
+
+cleanup() {
+  trap - EXIT INT TERM
+  [[ -n "${app_pid:-}" ]] && kill "$app_pid" 2>/dev/null || true
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Kill anything on port 1420 from a previous run
+stale_pids="$(lsof -t -nP -iTCP:1420 -sTCP:LISTEN 2>/dev/null || true)"
+if [[ -n "$stale_pids" ]]; then
+  kill $stale_pids 2>/dev/null || true
+  sleep 1
+fi
+
+# Full Tauri desktop app (Vite is started by tauri's beforeDevCommand)
+bun run dev &
+app_pid=$!
+wait "$app_pid"


### PR DESCRIPTION
Adds a `dev.sh` script that cleans up stale processes on port 1420 from previous runs, then launches the Tauri dev server with proper signal handling for clean shutdown.