### PR TITLE
Rename 'Claimed' kanban column to 'Planning'

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -43,7 +43,7 @@ Six columns, driven entirely by GitHub labels:
 | Column | Label | What's Happening |
 |---|---|---|
 | Backlog | (none) | No work started |
-| Claimed | `autodev:claimed` | Spec session running |
+| Planning | `autodev:planning` | Spec session running |
 | In Progress | `autodev:in-progress` | Implement or Review running |
 | Blocked | `autodev:blocked` | Needs human input |
 | Ready for Review | `autodev:review` | PR open, waiting for user |
@@ -53,7 +53,7 @@ Labels are the source of truth. When a repo is first added, AutoDev ensures the 
 
 ### Drag-and-Drop Rules
 
-- Cards can only be dragged from **Backlog → Claimed** (starts Spec) or **Backlog → In Progress** (skips Spec, starts Implement)
+- Cards can only be dragged from **Backlog → Planning** (starts Spec) or **Backlog → In Progress** (skips Spec, starts Implement)
 - **While a Claude session is active, the card is locked** — it cannot be dragged anywhere
 - All other column transitions are automated by the pipeline
 
@@ -122,7 +122,7 @@ All 5 stage prompts (Spec, Implement, Review, CI Fix, Merge Conflict) are user-e
 
 ## Git Worktrees
 
-Each issue gets its own git worktree so multiple issues can run in parallel without touching the user's main working tree. Worktrees are created when an issue is first claimed and deleted after the PR is merged.
+Each issue gets its own git worktree so multiple issues can run in parallel without touching the user's main working tree. Worktrees are created when an issue first enters planning and deleted after the PR is merged.
 
 - **Branch naming**: `{configurable prefix}issue-{number` (default: `autodev/issue-42`)
 - **Worktree path**: `~/.autodev/{repo-name}/issue-{number}/`

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -534,7 +534,7 @@ async fn ensure_labels(
     name: &str,
 ) -> Result<(), String> {
     let labels = [
-        ("autodev:claimed", "0E8A16"),
+        ("autodev:planning", "0E8A16"),
         ("autodev:in-progress", "1D76DB"),
         ("autodev:blocked", "E4E669"),
         ("autodev:review", "5319E7"),

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -10,7 +10,7 @@
 	// Local mutable copy of issues by column so DnD can update it optimistically
 	let columns = $state<Record<ColumnId, Issue[]>>({
 		backlog: [],
-		claimed: [],
+		planning: [],
 		in_progress: [],
 		blocked: [],
 		review: [],
@@ -22,7 +22,7 @@
 		const storeData = $issuesByColumn;
 		columns = {
 			backlog: [...storeData.backlog],
-			claimed: [...storeData.claimed],
+			planning: [...storeData.planning],
 			in_progress: [...storeData.in_progress],
 			blocked: [...storeData.blocked],
 			review: [...storeData.review],
@@ -52,7 +52,7 @@
 			(r) => r.owner === issue.repo_owner && r.name === issue.repo_name
 		);
 
-		if (targetColumn === 'claimed' && repo) {
+		if (targetColumn === 'planning' && repo) {
 			// Start a session — this creates the worktree + launches Claude
 			// The session will determine the column from now on (local state is king)
 			try {

--- a/src/lib/stores/issues.ts
+++ b/src/lib/stores/issues.ts
@@ -11,7 +11,7 @@ export const issuesByColumn = derived(
 	([$issues, $selectedRepoId, $repos, $sessionByIssue]) => {
 		const grouped: Record<ColumnId, Issue[]> = {
 			backlog: [],
-			claimed: [],
+			planning: [],
 			in_progress: [],
 			blocked: [],
 			review: [],

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,4 @@
-export type ColumnId = 'backlog' | 'claimed' | 'in_progress' | 'blocked' | 'review' | 'done';
+export type ColumnId = 'backlog' | 'planning' | 'in_progress' | 'blocked' | 'review' | 'done';
 
 export type SessionStage = 'spec' | 'implement' | 'review' | 'ci_fix' | 'merge_conflict';
 
@@ -87,7 +87,7 @@ export interface AppSettings {
 
 export const COLUMN_CONFIG: Record<ColumnId, { label: string; github_label: string | null }> = {
 	backlog: { label: 'Backlog', github_label: null },
-	claimed: { label: 'Claimed', github_label: 'autodev:claimed' },
+	planning: { label: 'Planning', github_label: 'autodev:planning' },
 	in_progress: { label: 'In Progress', github_label: 'autodev:in-progress' },
 	blocked: { label: 'Blocked', github_label: 'autodev:blocked' },
 	review: { label: 'Ready for Review', github_label: 'autodev:review' },
@@ -96,7 +96,7 @@ export const COLUMN_CONFIG: Record<ColumnId, { label: string; github_label: stri
 
 export const COLUMN_ORDER: ColumnId[] = [
 	'backlog',
-	'claimed',
+	'planning',
 	'in_progress',
 	'blocked',
 	'review',
@@ -110,7 +110,7 @@ export function getColumnForIssue(issue: Issue): ColumnId {
 	if (labelNames.includes('autodev:review')) return 'review';
 	if (labelNames.includes('autodev:blocked')) return 'blocked';
 	if (labelNames.includes('autodev:in-progress')) return 'in_progress';
-	if (labelNames.includes('autodev:claimed')) return 'claimed';
+	if (labelNames.includes('autodev:planning')) return 'planning';
 	return 'backlog';
 }
 
@@ -118,7 +118,7 @@ export function getColumnForIssue(issue: Issue): ColumnId {
 export function getColumnForSession(session: Session): ColumnId {
 	switch (session.stage) {
 		case 'spec':
-			return 'claimed';
+			return 'planning';
 		case 'implement':
 		case 'ci_fix':
 			return 'in_progress';


### PR DESCRIPTION
Renames the "Claimed" kanban column to "Planning" across the entire codebase. This includes the ColumnId type, COLUMN_CONFIG, GitHub label (`autodev:claimed` → `autodev:planning`), the Rust label provisioning, Svelte components/stores, and the spec docs.

Note: Repos that already have the `autodev:claimed` label on GitHub will need it renamed or re-labeled manually.