### PR TITLE
feat: add setup script for dev environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install JS dependencies
+bun install
+
+# Generate SvelteKit types
+bunx svelte-kit sync
+
+# Build Rust deps + generate Tauri schemas (non-interactive)
+cargo check --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
Adds a `setup.sh` script that bootstraps the dev environment: installs JS dependencies with bun, generates SvelteKit types, and builds Rust deps with cargo check.