### PR TITLE
feat: persist selected repo across app restarts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,8 @@ pub fn run() {
             sessions::prompts_set,
             sessions::set_repo_path,
             sessions::get_repo_path,
+            sessions::get_selected_repo_id,
+            sessions::set_selected_repo_id,
             // Caffeinate
             sessions::start_caffeinate,
             sessions::stop_caffeinate,

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -717,6 +717,23 @@ pub async fn get_repo_path(
     db::get_setting(&db, &format!("repo_{repo_id}_path"))
 }
 
+#[tauri::command]
+pub async fn get_selected_repo_id(
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<i64>, String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    Ok(db::get_setting(&db, "selected_repo_id")?.and_then(|v| v.parse::<i64>().ok()))
+}
+
+#[tauri::command]
+pub async fn set_selected_repo_id(
+    state: tauri::State<'_, AppState>,
+    repo_id: i64,
+) -> Result<(), String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::set_setting(&db, "selected_repo_id", &repo_id.to_string())
+}
+
 // ── Caffeinate ──────────────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src/lib/components/AddRepoDialog.svelte
+++ b/src/lib/components/AddRepoDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { showAddRepo } from '$lib/stores/ui';
-	import { repos, selectedRepoId } from '$lib/stores/repos';
+	import { repos, selectRepo } from '$lib/stores/repos';
 	import * as backend from '$lib/stores/backend';
 	import type { GitHubRepo } from '$lib/types';
 	import { FolderGit2, Loader2, Search } from 'lucide-svelte';
@@ -38,7 +38,7 @@
 		try {
 			const added = await backend.addRepo(repo.owner.login, repo.name);
 			repos.update((list) => [...list, added]);
-			selectedRepoId.set(added.id);
+			selectRepo(added.id);
 			close();
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);

--- a/src/lib/components/RepoSelector.svelte
+++ b/src/lib/components/RepoSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { DropdownMenu } from 'bits-ui';
-	import { repos, selectedRepoId } from '$lib/stores/repos';
+	import { repos, selectedRepoId, selectRepo as persistSelectRepo } from '$lib/stores/repos';
 	import { refreshIssues } from '$lib/stores/issues';
 	import { showAddRepo } from '$lib/stores/ui';
 	import { ChevronDown, Plus, FolderGit2 } from 'lucide-svelte';
@@ -10,7 +10,7 @@
 	let selectedRepo = $derived($repos.find((r) => r.id === $selectedRepoId));
 
 	function selectRepo(id: number) {
-		selectedRepoId.set(id);
+		persistSelectRepo(id);
 		open = false;
 		const repo = $repos.find((r) => r.id === id);
 		if (repo) {

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -196,6 +196,15 @@ export async function updatePrompt(stage: SessionStage, promptText: string): Pro
 	return invoke('update_prompt', { stage, promptText });
 }
 
+// Selected repo persistence
+export async function getSelectedRepoId(): Promise<number | null> {
+	return invoke('get_selected_repo_id');
+}
+
+export async function setSelectedRepoId(repoId: number): Promise<void> {
+	return invoke('set_selected_repo_id', { repoId });
+}
+
 // Polling
 export async function startPolling(): Promise<void> {
 	return invoke('start_polling');

--- a/src/lib/stores/repos.ts
+++ b/src/lib/stores/repos.ts
@@ -5,11 +5,18 @@ import * as backend from './backend';
 export const repos = writable<RepoConfig[]>([]);
 export const selectedRepoId = writable<number | null>(null);
 
+export async function selectRepo(id: number) {
+	selectedRepoId.set(id);
+	await backend.setSelectedRepoId(id);
+}
+
 export async function loadRepos(): Promise<RepoConfig[]> {
 	const list = await backend.getRepos();
 	repos.set(list);
 	if (list.length > 0) {
-		selectedRepoId.set(list[0].id);
+		const savedId = await backend.getSelectedRepoId();
+		const valid = savedId != null && list.some((r) => r.id === savedId);
+		selectedRepoId.set(valid ? savedId : list[0].id);
 	}
 	return list;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { authenticated, currentUser, authError, authLoading } from '$lib/stores/auth';
 	import { checkAuth, startAuth } from '$lib/stores/auth';
-	import { loadRepos } from '$lib/stores/repos';
+	import { loadRepos, selectedRepoId } from '$lib/stores/repos';
+	import { get } from 'svelte/store';
 	import { initBackend } from '$lib/stores/backend';
 	import { refreshIssues } from '$lib/stores/issues';
 	import { showNewIssueDialog, showSettings } from '$lib/stores/ui';
@@ -22,8 +23,10 @@
 			await initBackend();
 			await checkAuth();
 			const repoList = await loadRepos();
-			if (repoList.length > 0) {
-				await refreshIssues(repoList[0].owner, repoList[0].name);
+			const currentId = get(selectedRepoId);
+			const repo = repoList.find((r) => r.id === currentId) ?? repoList[0];
+			if (repo) {
+				await refreshIssues(repo.owner, repo.name);
 			}
 			loading = false;
 		} catch (e) {


### PR DESCRIPTION
## Summary

Stores the selected repo ID in the SQLite settings table so that reopening the app restores the last-viewed repository instead of always defaulting to the first one.

- Adds `get_selected_repo_id` / `set_selected_repo_id` Tauri commands using the existing settings key-value store
- Introduces a `selectRepo()` helper in the repos store that updates the Svelte store and persists to DB in one call
- `loadRepos()` now reads the persisted ID on startup and validates it still exists before applying

## Test plan
- [ ] Select a non-first repo, close and reopen the app — it should restore that repo
- [ ] Delete the selected repo and reopen — should fall back to the first repo
- [ ] Add a new repo via the dialog — it should become the selected repo and persist