### PR TITLE
feat: add repo removal with cascade cleanup

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -196,9 +196,74 @@ pub fn insert_repo(conn: &Connection, repo: &RepoConfig) -> Result<i64, String> 
     Ok(conn.last_insert_rowid())
 }
 
-pub fn delete_repo(conn: &Connection, repo_id: i64) -> Result<(), String> {
+/// Get all worktree paths for a repo's sessions.
+pub fn get_worktree_paths_for_repo(conn: &Connection, repo_id: i64) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("SELECT DISTINCT worktree_path FROM sessions WHERE repo_id = ?1 AND worktree_path IS NOT NULL")
+        .map_err(|e| format!("Failed to query worktree paths: {e}"))?;
+
+    let rows = stmt
+        .query_map(params![repo_id], |row| row.get::<_, String>(0))
+        .map_err(|e| format!("Failed to query worktree paths: {e}"))?;
+
+    let mut paths = Vec::new();
+    for row in rows {
+        paths.push(row.map_err(|e| format!("Failed to read worktree path: {e}"))?);
+    }
+    Ok(paths)
+}
+
+/// Count sessions for a repo.
+pub fn count_sessions_for_repo(conn: &Connection, repo_id: i64) -> Result<i64, String> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sessions WHERE repo_id = ?1",
+        params![repo_id],
+        |row| row.get(0),
+    )
+    .map_err(|e| format!("Failed to count sessions: {e}"))
+}
+
+/// Count session logs for a repo.
+pub fn count_session_logs_for_repo(conn: &Connection, repo_id: i64) -> Result<i64, String> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM session_logs WHERE session_id IN (SELECT id FROM sessions WHERE repo_id = ?1)",
+        params![repo_id],
+        |row| row.get(0),
+    )
+    .map_err(|e| format!("Failed to count session logs: {e}"))
+}
+
+/// Delete all data associated with a repo (sessions, logs, settings, then the repo itself).
+pub fn delete_repo_cascade(conn: &Connection, repo_id: i64) -> Result<(), String> {
+    // Delete session logs first (FK to sessions)
+    conn.execute(
+        "DELETE FROM session_logs WHERE session_id IN (SELECT id FROM sessions WHERE repo_id = ?1)",
+        params![repo_id],
+    )
+    .map_err(|e| format!("Failed to delete session logs: {e}"))?;
+
+    // Delete sessions
+    conn.execute("DELETE FROM sessions WHERE repo_id = ?1", params![repo_id])
+        .map_err(|e| format!("Failed to delete sessions: {e}"))?;
+
+    // Delete repo-specific settings
+    conn.execute(
+        "DELETE FROM settings WHERE key = ?1",
+        params![format!("repo_{repo_id}_path")],
+    )
+    .map_err(|e| format!("Failed to delete repo path setting: {e}"))?;
+
+    // Clear selected_repo_id if it points to this repo
+    conn.execute(
+        "DELETE FROM settings WHERE key = 'selected_repo_id' AND value = ?1",
+        params![repo_id.to_string()],
+    )
+    .map_err(|e| format!("Failed to clear selected repo: {e}"))?;
+
+    // Delete the repo itself
     conn.execute("DELETE FROM repos WHERE id = ?1", params![repo_id])
         .map_err(|e| format!("Failed to delete repo: {e}"))?;
+
     Ok(())
 }
 

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -199,12 +199,63 @@ pub async fn github_add_repo(
 }
 
 #[tauri::command]
+pub async fn github_get_repo_removal_info(
+    state: tauri::State<'_, AppState>,
+    repo_id: i64,
+) -> Result<RepoRemovalInfo, String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock error: {e}"))?;
+
+    let repo = db::get_repo_by_id(&db, repo_id)?
+        .ok_or_else(|| format!("Repo {repo_id} not found"))?;
+
+    let local_path = db::get_setting(&db, &format!("repo_{repo_id}_path"))?;
+    let worktree_paths = db::get_worktree_paths_for_repo(&db, repo_id)?;
+    let session_count = db::count_sessions_for_repo(&db, repo_id)?;
+    let log_count = db::count_session_logs_for_repo(&db, repo_id)?;
+
+    Ok(RepoRemovalInfo {
+        repo_name: repo.full_name,
+        local_path,
+        worktree_paths,
+        session_count,
+        log_count,
+    })
+}
+
+#[tauri::command]
 pub async fn github_remove_repo(
     state: tauri::State<'_, AppState>,
     repo_id: i64,
 ) -> Result<(), String> {
+    // Gather info before deleting
+    let (repo, repo_path, worktree_paths) = {
+        let db = state.db.lock().map_err(|e| format!("DB lock error: {e}"))?;
+        let repo = db::get_repo_by_id(&db, repo_id)?
+            .ok_or_else(|| format!("Repo {repo_id} not found"))?;
+        let repo_path = db::get_setting(&db, &format!("repo_{repo_id}_path"))?;
+        let worktree_paths = db::get_worktree_paths_for_repo(&db, repo_id)?;
+        (repo, repo_path, worktree_paths)
+    };
+
+    // Clean up worktrees on disk
+    if let Some(ref rp) = repo_path {
+        for wt_path in &worktree_paths {
+            // Extract issue number from worktree path to build branch name
+            let slug = std::path::Path::new(wt_path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("");
+            let branch_name = format!("{}{}", repo.branch_prefix, slug);
+
+            if let Err(e) = crate::worktrees::remove_worktree(rp, wt_path, &branch_name).await {
+                eprintln!("Warning: Failed to clean up worktree {wt_path}: {e}");
+            }
+        }
+    }
+
+    // Cascade delete all DB records
     let db = state.db.lock().map_err(|e| format!("DB lock error: {e}"))?;
-    db::delete_repo(&db, repo_id)
+    db::delete_repo_cascade(&db, repo_id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ pub fn run() {
             github::github_list_user_repos,
             github::github_add_repo,
             github::github_remove_repo,
+            github::github_get_repo_removal_info,
             github::github_get_repos,
             github::github_update_repo,
             // GitHub collaborators

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -120,6 +120,16 @@ pub struct GitHubRepoOwner {
     pub login: String,
 }
 
+/// Information about what will be deleted when removing a repo
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RepoRemovalInfo {
+    pub repo_name: String,
+    pub local_path: Option<String>,
+    pub worktree_paths: Vec<String>,
+    pub session_count: i64,
+    pub log_count: i64,
+}
+
 /// Events emitted to the frontend
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IssuesUpdatedEvent {

--- a/src/lib/components/RemoveRepoDialog.svelte
+++ b/src/lib/components/RemoveRepoDialog.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import { removeRepoId } from '$lib/stores/ui';
+	import { removeRepo } from '$lib/stores/repos';
+	import { getRepoRemovalInfo } from '$lib/stores/backend';
+	import { Loader2, Trash2, AlertTriangle } from 'lucide-svelte';
+	import type { RepoRemovalInfo } from '$lib/types';
+
+	let loading = $state(false);
+	let removing = $state(false);
+	let error = $state('');
+	let info = $state<RepoRemovalInfo | null>(null);
+
+	$effect(() => {
+		if ($removeRepoId != null) {
+			loading = true;
+			error = '';
+			info = null;
+			getRepoRemovalInfo($removeRepoId)
+				.then((result) => { info = result; })
+				.catch((e) => { error = e instanceof Error ? e.message : String(e); })
+				.finally(() => { loading = false; });
+		}
+	});
+
+	async function handleRemove() {
+		if ($removeRepoId == null || removing) return;
+		removing = true;
+		error = '';
+		try {
+			await removeRepo($removeRepoId);
+			close();
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			removing = false;
+		}
+	}
+
+	function close() {
+		removeRepoId.set(null);
+		info = null;
+		error = '';
+		removing = false;
+	}
+</script>
+
+{#if $removeRepoId != null}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="fixed inset-0 z-50 flex items-center justify-center" onkeydown={(e) => { if (e.key === 'Escape') close(); }}>
+		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+		<div class="absolute inset-0 bg-black/40" onclick={close}></div>
+		<div class="relative bg-popover border border-border rounded-lg shadow-xl w-96 flex flex-col max-h-[70vh] overflow-hidden">
+			{#if loading}
+				<div class="flex items-center justify-center py-12 text-muted-foreground">
+					<Loader2 class="h-4 w-4 animate-spin mr-2" />
+					<span class="text-sm">Loading removal info...</span>
+				</div>
+			{:else if error && !info}
+				<div class="p-4">
+					<div class="text-sm text-red-400">{error}</div>
+					<div class="mt-3 flex justify-end">
+						<button
+							class="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+							onclick={close}
+						>
+							Close
+						</button>
+					</div>
+				</div>
+			{:else if info}
+				<div class="p-4">
+					<div class="flex items-center gap-2 mb-3">
+						<AlertTriangle class="h-5 w-5 text-red-400 shrink-0" />
+						<h3 class="text-sm font-semibold text-foreground">Remove Repository</h3>
+					</div>
+
+					<p class="text-sm text-foreground mb-3">
+						Are you sure you want to remove <span class="font-semibold">{info.repo_name}</span>?
+					</p>
+
+					{#if error}
+						<div class="text-sm text-red-400 mb-3">{error}</div>
+					{/if}
+
+					<p class="text-sm text-muted-foreground mb-2">The following will be permanently deleted:</p>
+
+					<div class="bg-muted/50 rounded-md border border-border p-3 mb-4">
+						{#if info.local_path}
+							<div class="text-sm text-muted-foreground">
+								<span>&#8226;</span> Local repo path setting: <span class="font-mono">{info.local_path}</span>
+							</div>
+						{/if}
+						{#each info.worktree_paths as path (path)}
+							<div class="text-sm text-muted-foreground">
+								<span>&#8226;</span> Worktree: <span class="font-mono">{path}</span>
+							</div>
+						{/each}
+						{#if info.session_count > 0}
+							<div class="text-sm text-muted-foreground">
+								<span>&#8226;</span> {info.session_count} session record{info.session_count === 1 ? '' : 's'}
+							</div>
+						{/if}
+						{#if info.log_count > 0}
+							<div class="text-sm text-muted-foreground">
+								<span>&#8226;</span> {info.log_count} session log{info.log_count === 1 ? '' : 's'}
+							</div>
+						{/if}
+						<div class="text-sm text-muted-foreground">
+							<span>&#8226;</span> Database entry for <span class="font-semibold">{info.repo_name}</span>
+						</div>
+					</div>
+				</div>
+
+				<div class="shrink-0 p-3 border-t border-border flex justify-end gap-2">
+					<button
+						class="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+						onclick={close}
+						disabled={removing}
+					>
+						Cancel
+					</button>
+					<button
+						class="px-3 py-1.5 text-sm rounded-md bg-red-600 hover:bg-red-700 text-white transition-colors flex items-center gap-1.5 disabled:opacity-50"
+						onclick={handleRemove}
+						disabled={removing}
+					>
+						{#if removing}
+							<Loader2 class="h-3.5 w-3.5 animate-spin" />
+						{:else}
+							<Trash2 class="h-3.5 w-3.5" />
+						{/if}
+						Remove
+					</button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/RepoSelector.svelte
+++ b/src/lib/components/RepoSelector.svelte
@@ -2,8 +2,8 @@
 	import { DropdownMenu } from 'bits-ui';
 	import { repos, selectedRepoId, selectRepo as persistSelectRepo } from '$lib/stores/repos';
 	import { refreshIssues } from '$lib/stores/issues';
-	import { showAddRepo } from '$lib/stores/ui';
-	import { ChevronDown, Plus, FolderGit2 } from 'lucide-svelte';
+	import { showAddRepo, removeRepoId } from '$lib/stores/ui';
+	import { ChevronDown, Plus, FolderGit2, Trash2 } from 'lucide-svelte';
 
 	let open = $state(false);
 
@@ -16,6 +16,12 @@
 		if (repo) {
 			refreshIssues(repo.owner, repo.name);
 		}
+	}
+
+	function handleRemove(e: MouseEvent, repoId: number) {
+		e.stopPropagation();
+		open = false;
+		removeRepoId.set(repoId);
 	}
 </script>
 
@@ -41,11 +47,17 @@
 
 			{#each $repos as repo (repo.id)}
 				<DropdownMenu.Item
-					class="flex items-center gap-2 px-3 py-2 text-sm rounded-md cursor-pointer hover:bg-accent hover:text-accent-foreground outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground {repo.id === $selectedRepoId ? 'bg-accent/50' : ''}"
+					class="group flex items-center gap-2 px-3 py-2 text-sm rounded-md cursor-pointer hover:bg-accent hover:text-accent-foreground outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground {repo.id === $selectedRepoId ? 'bg-accent/50' : ''}"
 					onSelect={() => selectRepo(repo.id)}
 				>
 					<FolderGit2 class="h-3.5 w-3.5 text-muted-foreground" />
-					{repo.full_name}
+					<span class="flex-1 truncate">{repo.full_name}</span>
+					<button
+						class="hidden group-hover:flex items-center justify-center h-5 w-5 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors"
+						onclick={(e) => handleRemove(e, repo.id)}
+					>
+						<Trash2 class="h-3 w-3" />
+					</button>
 				</DropdownMenu.Item>
 			{/each}
 

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -7,6 +7,7 @@ import type {
 	GitHubUser,
 	GitHubRepo,
 	RepoConfig,
+	RepoRemovalInfo,
 	AppSettings,
 	AgentPrompt,
 	SessionStage
@@ -91,6 +92,10 @@ export async function listUserRepos(): Promise<GitHubRepo[]> {
 
 export async function addRepo(owner: string, name: string): Promise<RepoConfig> {
 	return invoke('github_add_repo', { owner, name });
+}
+
+export async function getRepoRemovalInfo(repoId: number): Promise<RepoRemovalInfo> {
+	return invoke('github_get_repo_removal_info', { repoId });
 }
 
 export async function removeRepo(repoId: number): Promise<void> {

--- a/src/lib/stores/repos.ts
+++ b/src/lib/stores/repos.ts
@@ -10,6 +10,16 @@ export async function selectRepo(id: number) {
 	await backend.setSelectedRepoId(id);
 }
 
+export async function removeRepo(id: number) {
+	await backend.removeRepo(id);
+	repos.update((list) => list.filter((r) => r.id !== id));
+	// If the removed repo was selected, select another or clear
+	selectedRepoId.update((current) => {
+		if (current === id) return null;
+		return current;
+	});
+}
+
 export async function loadRepos(): Promise<RepoConfig[]> {
 	const list = await backend.getRepos();
 	repos.set(list);

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -5,3 +5,4 @@ export const selectedIssue = writable<Issue | null>(null);
 export const showNewIssueDialog = writable(false);
 export const showSettings = writable(false);
 export const showAddRepo = writable(false);
+export const removeRepoId = writable<number | null>(null);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -73,6 +73,14 @@ export interface RepoConfig {
 	worktree_dir: string;
 }
 
+export interface RepoRemovalInfo {
+	repo_name: string;
+	local_path: string | null;
+	worktree_paths: string[];
+	session_count: number;
+	log_count: number;
+}
+
 export interface AgentPrompt {
 	stage: SessionStage;
 	prompt_text: string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 	import NewIssueDialog from '$lib/components/NewIssueDialog.svelte';
 	import SettingsDialog from '$lib/components/SettingsDialog.svelte';
 	import AddRepoDialog from '$lib/components/AddRepoDialog.svelte';
+	import RemoveRepoDialog from '$lib/components/RemoveRepoDialog.svelte';
 	import { Settings, Plus, Loader2 } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
@@ -148,5 +149,6 @@
 		<NewIssueDialog />
 		<SettingsDialog />
 		<AddRepoDialog />
+		<RemoveRepoDialog />
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

- Adds the ability to remove a repository from AutoDev via a trash icon in the repo selector dropdown (appears on hover)
- A confirmation dialog fetches and displays all data that will be deleted: worktree directories, session records, session logs, local path settings, and the database entry
- Backend performs full cascade cleanup: removes git worktrees from disk, then deletes all associated DB records (session_logs, sessions, settings, repo)

## Test plan

- [ ] Add a repo, then remove it via the trash icon in the repo selector
- [ ] Verify the confirmation dialog lists all associated data
- [ ] Verify worktree directories are cleaned up on disk after removal
- [ ] Verify removing the currently selected repo clears the selection
- [ ] Verify cancelling the dialog does not delete anything