### PR TITLE
feat: conversational agent log UI and fix log persistence

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -132,6 +132,40 @@ fn run_migrations(conn: &Connection) -> Result<(), String> {
         eprintln!("[DB] Migration complete");
     }
 
+    // Migration: recreate session_logs with INTEGER types and no CHECK constraint.
+    // The old table used TEXT PRIMARY KEY for id (never auto-assigned) and TEXT session_id.
+    let needs_logs_migration: bool = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='session_logs'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap_or(None)
+        .map(|sql| sql.contains("id TEXT PRIMARY KEY") || sql.contains("CHECK(event_type"))
+        .unwrap_or(false);
+
+    if needs_logs_migration {
+        eprintln!("[DB] Migrating session_logs table: fixing column types");
+        conn.execute_batch(
+            "
+            CREATE TABLE session_logs_new (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL REFERENCES sessions(id),
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                content TEXT NOT NULL
+            );
+            INSERT INTO session_logs_new (session_id, timestamp, event_type, content)
+                SELECT CAST(session_id AS INTEGER), timestamp, event_type, content FROM session_logs;
+            DROP TABLE session_logs;
+            ALTER TABLE session_logs_new RENAME TO session_logs;
+            CREATE INDEX IF NOT EXISTS idx_session_logs_session ON session_logs(session_id);
+            ",
+        )
+        .map_err(|e| format!("Failed to migrate session_logs table: {e}"))?;
+        eprintln!("[DB] session_logs migration complete");
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -902,7 +902,7 @@ fn parse_stream_json_line(line: &str) -> Vec<(String, String)> {
 
     match raw_type {
         // System init events — not useful in the activity log
-        "system" => vec![],
+        "system" | "user" | "rate_limit_event" => vec![],
 
         // Assistant messages — may contain text and/or tool_use blocks
         "assistant" => {

--- a/src/lib/components/AgentLog.svelte
+++ b/src/lib/components/AgentLog.svelte
@@ -1,27 +1,35 @@
 <script lang="ts">
 	import { sessionLogs } from '$lib/stores/sessions';
 	import { fetchSessionLogs } from '$lib/stores/backend';
-	import { Wrench, MessageSquare, AlertCircle, RefreshCw, Terminal } from 'lucide-svelte';
+	import type { SessionLogEntry } from '$lib/types';
+	import { Wrench, AlertCircle, ChevronRight, ChevronDown, Terminal } from 'lucide-svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	let { sessionId }: { sessionId: string } = $props();
 
 	let container: HTMLDivElement | undefined = $state(undefined);
 
-	let logs = $derived(($sessionLogs.get(sessionId) ?? []).slice());
+	const NOISE_TYPES = new Set(['user', 'rate_limit_event', 'system']);
+	let logs = $derived(
+		($sessionLogs.get(sessionId) ?? []).filter((e) => !NOISE_TYPES.has(e.event_type))
+	);
 
 	$effect(() => {
-		// Load persisted logs from the DB if none exist in the store yet
-		const currentLogs = $sessionLogs.get(sessionId);
-		if (!currentLogs || currentLogs.length === 0) {
-			fetchSessionLogs(sessionId).then((entries) => {
-				if (entries.length > 0) {
-					sessionLogs.update((current) => {
-						current.set(sessionId, entries);
+		// Load persisted logs from the DB whenever sessionId changes
+		const id = sessionId;
+		fetchSessionLogs(id).then((entries) => {
+			if (entries.length > 0) {
+				sessionLogs.update((current) => {
+					// Only set if the store doesn't already have fresher data (from live events)
+					const existing = current.get(id);
+					if (!existing || existing.length === 0) {
+						current.set(id, entries);
 						return new Map(current);
-					});
-				}
-			});
-		}
+					}
+					return current;
+				});
+			}
+		});
 	});
 
 	$effect(() => {
@@ -40,38 +48,149 @@
 		const d = new Date(ts);
 		return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 	}
+
+	/** Extract tool name from content like "Bash: some command" -> "Bash" */
+	function toolName(content: string): string {
+		const idx = content.indexOf(':');
+		if (idx > 0 && idx < 30) {
+			return content.substring(0, idx).trim();
+		}
+		return content.trim();
+	}
+
+	type LogGroup =
+		| { kind: 'message'; entry: SessionLogEntry }
+		| { kind: 'error'; entry: SessionLogEntry }
+		| { kind: 'status_change'; entry: SessionLogEntry }
+		| { kind: 'test_output'; entry: SessionLogEntry }
+		| { kind: 'tool_calls'; entries: SessionLogEntry[] };
+
+	let groups = $derived.by((): LogGroup[] => {
+		const result: LogGroup[] = [];
+		let i = 0;
+		while (i < logs.length) {
+			const entry = logs[i];
+			if (entry.event_type === 'tool_call') {
+				const batch: SessionLogEntry[] = [entry];
+				i++;
+				while (i < logs.length && logs[i].event_type === 'tool_call') {
+					batch.push(logs[i]);
+					i++;
+				}
+				result.push({ kind: 'tool_calls', entries: batch });
+			} else if (entry.event_type === 'message') {
+				result.push({ kind: 'message', entry });
+				i++;
+			} else if (entry.event_type === 'error') {
+				result.push({ kind: 'error', entry });
+				i++;
+			} else if (entry.event_type === 'status_change') {
+				result.push({ kind: 'status_change', entry });
+				i++;
+			} else if (entry.event_type === 'test_output') {
+				result.push({ kind: 'test_output', entry });
+				i++;
+			} else {
+				result.push({ kind: 'message', entry });
+				i++;
+			}
+		}
+		return result;
+	});
+
+	let expandedGroups = new SvelteSet<number>();
+
+	function toggleGroup(index: number) {
+		if (expandedGroups.has(index)) {
+			expandedGroups.delete(index);
+		} else {
+			expandedGroups.add(index);
+		}
+	}
 </script>
 
-<div bind:this={container} class="flex-1 overflow-y-auto space-y-1 pr-1">
+<div bind:this={container} class="flex-1 overflow-y-auto pr-1 space-y-3 py-2">
 	{#if logs.length === 0}
 		<div class="flex items-center justify-center h-full">
 			<p class="text-sm text-muted-foreground">No activity yet.</p>
 		</div>
 	{:else}
-		{#each logs as entry (entry.id)}
-			<div
-				class="flex items-start gap-2 px-2 py-1.5 rounded-md text-sm
-					{entry.event_type === 'error' ? 'bg-destructive/10 text-red-400' : ''}
-					{entry.event_type === 'tool_call' ? 'bg-muted/50 font-mono text-xs' : ''}
-					{entry.event_type === 'test_output' ? 'bg-muted/50 font-mono text-xs' : ''}
-				"
-			>
-				<span class="mt-0.5 shrink-0 text-muted-foreground">
-					{#if entry.event_type === 'tool_call'}
-						<Wrench class="h-3.5 w-3.5" />
-					{:else if entry.event_type === 'message'}
-						<MessageSquare class="h-3.5 w-3.5" />
-					{:else if entry.event_type === 'error'}
-						<AlertCircle class="h-3.5 w-3.5 text-red-400" />
-					{:else if entry.event_type === 'test_output'}
-						<Terminal class="h-3.5 w-3.5" />
-					{:else}
-						<RefreshCw class="h-3.5 w-3.5" />
-					{/if}
-				</span>
-				<span class="shrink-0 text-muted-foreground text-xs mt-px">{formatTime(entry.timestamp)}</span>
-				<span class="break-words min-w-0">{entry.content}</span>
-			</div>
+		{#each groups as group, groupIndex (groupIndex)}
+			{#if group.kind === 'message'}
+				<!-- Message: clean readable text -->
+				<div class="px-2">
+					<p class="text-sm text-foreground/90 leading-relaxed whitespace-pre-wrap">{group.entry.content}</p>
+					<span class="text-[10px] text-muted-foreground/60 mt-1 block">{formatTime(group.entry.timestamp)}</span>
+				</div>
+
+			{:else if group.kind === 'tool_calls'}
+				<!-- Tool calls: collapsible group -->
+				{#if group.entries.length === 1}
+					<!-- Single tool call: inline pill -->
+					<div class="px-2">
+						<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-muted/60 text-xs text-muted-foreground">
+							<Wrench class="h-3 w-3" />
+							{toolName(group.entries[0].content)}
+						</span>
+					</div>
+				{:else}
+					<!-- Multiple tool calls: collapsible -->
+					<div class="px-2">
+						<button
+							type="button"
+							class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-muted/60 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+							onclick={() => toggleGroup(groupIndex)}
+						>
+							{#if expandedGroups.has(groupIndex)}
+								<ChevronDown class="h-3 w-3" />
+							{:else}
+								<ChevronRight class="h-3 w-3" />
+							{/if}
+							<Wrench class="h-3 w-3" />
+							Used {group.entries.length} tools
+						</button>
+						{#if expandedGroups.has(groupIndex)}
+							<div class="mt-1.5 ml-2 pl-3 border-l-2 border-border space-y-0.5">
+								{#each group.entries as toolEntry (toolEntry.id)}
+									<div class="text-xs text-muted-foreground py-0.5 flex items-center gap-1.5">
+										<Wrench class="h-2.5 w-2.5 shrink-0" />
+										<span class="font-medium text-foreground/70">{toolName(toolEntry.content)}</span>
+										<span class="text-muted-foreground/50 truncate">{toolEntry.content.substring(toolEntry.content.indexOf(':') + 1).trim()}</span>
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+
+			{:else if group.kind === 'error'}
+				<!-- Error: compact red alert -->
+				<div class="mx-2 flex items-start gap-2 px-3 py-2 rounded-md bg-destructive/10 border border-red-500/20">
+					<AlertCircle class="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
+					<div class="min-w-0">
+						<p class="text-sm text-red-400 break-words">{group.entry.content}</p>
+						<span class="text-[10px] text-red-400/50 mt-0.5 block">{formatTime(group.entry.timestamp)}</span>
+					</div>
+				</div>
+
+			{:else if group.kind === 'status_change'}
+				<!-- Status change: centered divider -->
+				<div class="flex items-center gap-3 px-2 py-1">
+					<div class="flex-1 h-px bg-border"></div>
+					<span class="text-[10px] text-muted-foreground/60 uppercase tracking-wider whitespace-nowrap">{group.entry.content}</span>
+					<div class="flex-1 h-px bg-border"></div>
+				</div>
+
+			{:else if group.kind === 'test_output'}
+				<!-- Test output: monospace code block -->
+				<div class="mx-2">
+					<div class="flex items-center gap-1.5 mb-1">
+						<Terminal class="h-3 w-3 text-muted-foreground" />
+						<span class="text-[10px] text-muted-foreground uppercase tracking-wider">Test Output</span>
+					</div>
+					<pre class="text-xs font-mono bg-muted/50 rounded-md p-3 overflow-x-auto text-foreground/80 whitespace-pre-wrap break-words border border-border/50">{group.entry.content}</pre>
+				</div>
+			{/if}
 		{/each}
 	{/if}
 </div>

--- a/src/lib/components/CardDetail.svelte
+++ b/src/lib/components/CardDetail.svelte
@@ -130,10 +130,38 @@
 	function handleCopyConversation() {
 		if (!activeSession) return;
 		const logs = $sessionLogs.get(activeSession.id) ?? [];
-		const text = logs
-			.map((entry) => `[${entry.timestamp}] [${entry.event_type}] ${entry.content}`)
-			.join('\n');
-		navigator.clipboard.writeText(text).then(() => {
+		const parts: string[] = [];
+		let toolBatch: string[] = [];
+
+		function flushTools() {
+			if (toolBatch.length === 0) return;
+			if (toolBatch.length === 1) {
+				parts.push(`  [tool] ${toolBatch[0]}`);
+			} else {
+				parts.push(`  [${toolBatch.length} tools] ${toolBatch.map(t => t.split(':')[0].trim()).join(', ')}`);
+			}
+			toolBatch = [];
+		}
+
+		for (const entry of logs) {
+			if (entry.event_type === 'tool_call') {
+				toolBatch.push(entry.content);
+			} else {
+				flushTools();
+				if (entry.event_type === 'message') {
+					parts.push(entry.content);
+				} else if (entry.event_type === 'error') {
+					parts.push(`[error] ${entry.content}`);
+				} else if (entry.event_type === 'status_change') {
+					parts.push(`--- ${entry.content} ---`);
+				} else if (entry.event_type === 'test_output') {
+					parts.push(`[test]\n${entry.content}`);
+				}
+			}
+		}
+		flushTools();
+
+		navigator.clipboard.writeText(parts.join('\n\n')).then(() => {
 			copied = true;
 			setTimeout(() => { copied = false; }, 2000);
 		});


### PR DESCRIPTION
## Summary
- Redesign AgentLog from flat log lines into a chat-like conversational UI: message bubbles, collapsible tool call groups, status dividers, and styled error/test blocks
- Filter noise events (`user`, `rate_limit_event`) from Claude CLI stream-json output in both Rust parser and frontend
- Fix session logs not loading after app restart — the DB had a TEXT schema mismatch (TEXT id/session_id) vs the INTEGER types the Rust queries expected; adds a migration to fix existing databases
- Clean up copy-conversation output to produce readable text instead of raw log lines

## Test plan
- [ ] Run a new session and verify the log shows messages as text, tool calls as collapsible pills, and status changes as dividers
- [ ] Close and reopen the app — verify session logs persist and load correctly
- [ ] Click "copy conversation" and verify the output is clean readable text