### PR TITLE
feat: configurable agent permission mode (auto default, bypass opt-in)

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -747,11 +747,15 @@ pub fn get_app_settings(conn: &Connection) -> Result<AppSettings, String> {
     let poll = get_setting(conn, "poll_interval_seconds")?
         .and_then(|v| v.parse::<i64>().ok())
         .unwrap_or(defaults.poll_interval_seconds);
+    let bypass = get_setting(conn, "bypass_permissions")?
+        .map(|v| v == "true")
+        .unwrap_or(defaults.bypass_permissions);
 
     Ok(AppSettings {
         sleep_prevention: sleep,
         notifications_enabled: notif,
         poll_interval_seconds: poll,
+        bypass_permissions: bypass,
     })
 }
 
@@ -759,6 +763,7 @@ pub fn save_app_settings(conn: &Connection, settings: &AppSettings) -> Result<()
     set_setting(conn, "sleep_prevention", &settings.sleep_prevention.to_string())?;
     set_setting(conn, "notifications_enabled", &settings.notifications_enabled.to_string())?;
     set_setting(conn, "poll_interval_seconds", &settings.poll_interval_seconds.to_string())?;
+    set_setting(conn, "bypass_permissions", &settings.bypass_permissions.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -330,6 +330,12 @@ pub async fn session_start_implement(
     };
     crate::sleep::on_session_start(sleep_enabled).await;
 
+    let permission_mode = {
+        let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+        let settings = db::get_app_settings(&db)?;
+        if settings.bypass_permissions { "bypassPermissions" } else { "auto" }
+    }.to_string();
+
     let app = app_handle.clone();
     let wt_path = worktree_path.clone();
     let user_prompt = format!(
@@ -343,7 +349,7 @@ pub async fn session_start_implement(
             &wt_path,
             &implement_prompt,
             &user_prompt,
-            "bypassPermissions",
+            &permission_mode,
             session_db_id,
             &app,
         )
@@ -470,6 +476,12 @@ pub async fn session_start_review(
     };
     crate::sleep::on_session_start(sleep_enabled).await;
 
+    let permission_mode = {
+        let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+        let settings = db::get_app_settings(&db)?;
+        if settings.bypass_permissions { "bypassPermissions" } else { "auto" }
+    }.to_string();
+
     let app = app_handle.clone();
     let wt_path = worktree_path.clone();
     let owner = repo.owner.clone();
@@ -486,7 +498,7 @@ pub async fn session_start_review(
             &wt_path,
             &review_prompt,
             &user_prompt,
-            "bypassPermissions",
+            &permission_mode,
             session_db_id,
             &app,
         )
@@ -591,9 +603,11 @@ pub async fn session_respond(
     };
 
     let permission_mode = if stage == "spec" {
-        "plan"
+        "plan".to_string()
     } else {
-        "bypassPermissions"
+        let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+        let settings = db::get_app_settings(&db)?;
+        if settings.bypass_permissions { "bypassPermissions".to_string() } else { "auto".to_string() }
     };
 
     // Create new session entry for the resumed work
@@ -631,7 +645,7 @@ pub async fn session_respond(
             &wt_path,
             &prompt,
             &message,
-            permission_mode,
+            &permission_mode,
             new_db_id,
             &app,
         )

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -86,6 +86,7 @@ pub struct AppSettings {
     pub sleep_prevention: bool,
     pub notifications_enabled: bool,
     pub poll_interval_seconds: i64,
+    pub bypass_permissions: bool,
 }
 
 impl Default for AppSettings {
@@ -94,6 +95,7 @@ impl Default for AppSettings {
             sleep_prevention: true,
             notifications_enabled: true,
             poll_interval_seconds: 15,
+            bypass_permissions: false,
         }
     }
 }

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -11,7 +11,8 @@
 	let localSettings = $state<AppSettings>({
 		sleep_prevention: true,
 		notifications_enabled: true,
-		poll_interval_seconds: 15
+		poll_interval_seconds: 15,
+		bypass_permissions: false
 	});
 
 	// Local copies of prompts
@@ -172,6 +173,33 @@
 								class="w-24 bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring"
 								bind:value={localSettings.poll_interval_seconds}
 							/>
+						</div>
+					</div>
+
+					<div class="border-t border-border pt-4 mt-4 space-y-3">
+						<div>
+							<p class="text-sm font-medium text-foreground">Agent Permissions</p>
+							<p class="text-xs text-muted-foreground">Controls how much autonomy agents have when running tasks</p>
+						</div>
+
+						<div class="flex items-center justify-between">
+							<div>
+								<p class="text-sm font-medium text-foreground">Bypass All Permissions</p>
+								<p class="text-xs text-muted-foreground">
+									{#if localSettings.bypass_permissions}
+										Agents run with no permission checks. Use only in trusted repos.
+									{:else}
+										Agents use auto mode — an AI classifier approves safe actions.
+									{/if}
+								</p>
+							</div>
+							<Switch.Root
+								checked={localSettings.bypass_permissions}
+								onCheckedChange={(checked) => { localSettings.bypass_permissions = checked; }}
+								class="relative h-5 w-9 rounded-full bg-muted transition-colors data-[state=checked]:bg-destructive"
+							>
+								<Switch.Thumb class="block h-4 w-4 rounded-full bg-background shadow-sm transition-transform data-[state=checked]:translate-x-4 translate-x-0.5" />
+							</Switch.Root>
 						</div>
 					</div>
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,7 +5,8 @@ import * as backend from './backend';
 export const appSettings = writable<AppSettings>({
 	sleep_prevention: true,
 	notifications_enabled: true,
-	poll_interval_seconds: 15
+	poll_interval_seconds: 15,
+	bypass_permissions: false
 });
 
 export const agentPrompts = writable<AgentPrompt[]>([]);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -90,6 +90,7 @@ export interface AppSettings {
 	sleep_prevention: boolean;
 	notifications_enabled: boolean;
 	poll_interval_seconds: number;
+	bypass_permissions: boolean;
 }
 
 export const COLUMN_CONFIG: Record<ColumnId, { label: string; github_label: string | null }> = {


### PR DESCRIPTION
## Summary
- Adds a `bypass_permissions` setting to `AppSettings`, persisted in SQLite.
- Changes the default agent permission mode from `bypassPermissions` to `auto` (AI classifier) for implement, review, and respond stages. Spec stage remains `plan`.
- Adds a "Bypass All Permissions" toggle in the Settings dialog with a red destructive-colored switch and contextual description.

## Test plan
- [ ] Open Settings > App Settings and verify the new "Bypass All Permissions" toggle appears
- [ ] With toggle off (default), start an implement session and confirm Claude runs with `--permission-mode auto`
- [ ] With toggle on, start an implement session and confirm Claude runs with `--permission-mode bypassPermissions`
- [ ] Verify the setting persists across app restarts