### PR TITLE
feat: chat interface with closable tabs, history, and spec workflow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tauri-apps/cli": "^2.0.0",
+        "@types/node": "^25.5.2",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "svelte": "^5.0.0",
@@ -207,6 +208,8 @@
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -429,6 +432,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/cli": "^2.0.0",
+    "@types/node": "^25.5.2",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "svelte": "^5.0.0",

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -166,6 +166,26 @@ fn run_migrations(conn: &Connection) -> Result<(), String> {
         eprintln!("[DB] session_logs migration complete");
     }
 
+    // Migration: add hidden column to sessions
+    let has_hidden: bool = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap_or(None)
+        .map(|sql| sql.contains("hidden"))
+        .unwrap_or(false);
+
+    if !has_hidden {
+        eprintln!("[DB] Migrating sessions table: adding hidden column");
+        conn.execute_batch(
+            "ALTER TABLE sessions ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;",
+        )
+        .map_err(|e| format!("Failed to add hidden column: {e}"))?;
+        eprintln!("[DB] hidden column migration complete");
+    }
+
     Ok(())
 }
 
@@ -173,23 +193,35 @@ fn seed_default_prompts(conn: &Connection) -> Result<(), String> {
     let defaults: &[(&str, &str)] = &[
         (
             "spec",
-            "You are an AI developer analyzing a GitHub issue to produce a specification.\n\n\
+            "You are an AI developer analyzing a GitHub issue to produce a specification.\n\
+             You have access to the `gh` CLI for interacting with GitHub.\n\n\
              ## Process\n\
-             1. Read the issue thoroughly — understand the problem, not just the title.\n\
-             2. Explore the codebase to understand the architecture, conventions, and relevant code paths.\n\
-             3. Identify all files that will need to change and any new files that need to be created.\n\
-             4. Write a specification comment on the issue.\n\n\
+             1. Check for an existing spec by reading the issue's comments:\n\
+             \x20  `gh api repos/{owner}/{repo}/issues/{number}/comments --jq '.[].body'`\n\
+             \x20  Look for a comment that starts with \"## Spec\" or contains a specification.\n\
+             2. **If an existing spec is found**: Present it to the user and ask if there's anything they'd like to update. If they confirm it's good, skip to step 6.\n\
+             3. **If no spec exists**: Read the issue thoroughly and explore the codebase to understand the architecture, conventions, and relevant code paths.\n\
+             4. If you have blocking questions that prevent you from writing the spec:\n\
+             \x20  a. Post a comment on the issue with your questions: `gh issue comment {number} -R {owner}/{repo} --body \"## Questions\\n\\n...\"`\n\
+             \x20  b. Add the blocked label: `gh issue edit {number} -R {owner}/{repo} --add-label \"autodev:blocked\"`\n\
+             \x20  c. Remove the planning label if present: `gh issue edit {number} -R {owner}/{repo} --remove-label \"autodev:planning\"`\n\
+             \x20  d. Stop and tell the user you've posted questions on the issue.\n\
+             5. Write the spec and post it as a comment on the issue:\n\
+             \x20  `gh issue comment {number} -R {owner}/{repo} --body \"## Spec\\n\\n...\"`\n\
+             6. Move the issue to in-progress to trigger implementation:\n\
+             \x20  a. Add the in-progress label: `gh issue edit {number} -R {owner}/{repo} --add-label \"autodev:in-progress\"`\n\
+             \x20  b. Remove planning/blocked labels if present: `gh issue edit {number} -R {owner}/{repo} --remove-label \"autodev:planning\" --remove-label \"autodev:blocked\"`\n\n\
              ## Specification format\n\
              Your spec comment should include:\n\
              - **Summary**: One-sentence description of what this change does.\n\
              - **Relevant files**: List every file you expect to touch, with a brief note on what changes.\n\
              - **Approach**: Step-by-step plan for the implementation. Be specific — reference functions, types, and modules by name.\n\
-             - **Edge cases**: Anything that could go wrong or needs special handling.\n\
-             - **Questions**: If anything is ambiguous, list your questions clearly. If you have no questions, say \"No questions — ready to implement.\"\n\n\
+             - **Edge cases**: Anything that could go wrong or needs special handling.\n\n\
              ## Rules\n\
              - Do NOT make any code changes. This is a read-only analysis stage.\n\
              - Do NOT guess at implementation details you haven't verified by reading the code.\n\
-             - Keep the spec concise and actionable — a developer should be able to implement from it.",
+             - Keep the spec concise and actionable — a developer should be able to implement from it.\n\
+             - Always use the `gh` CLI to interact with GitHub — never modify labels or comments through any other means.",
         ),
         (
             "implement",
@@ -542,33 +574,35 @@ pub fn update_session_cli_id(
     Ok(())
 }
 
+fn row_to_session(row: &rusqlite::Row) -> rusqlite::Result<Session> {
+    Ok(Session {
+        id: format!("{}", row.get::<_, i64>(0)?),
+        repo_id: row.get(1)?,
+        issue_number: row.get(2)?,
+        stage: row.get(3)?,
+        worktree_path: row.get(4)?,
+        session_id: row.get(5)?,
+        status: row.get(6)?,
+        error_message: row.get(7)?,
+        started_at: row.get(8)?,
+        completed_at: row.get(9)?,
+        hidden: row.get::<_, i64>(10).unwrap_or(0) != 0,
+    })
+}
+
+const SESSION_COLS: &str = "id, repo_id, issue_number, stage, worktree_path, session_id, status, error_message, started_at, completed_at, hidden";
+
 pub fn get_active_session(
     conn: &Connection,
     repo_id: i64,
     issue_number: i64,
 ) -> Result<Option<Session>, String> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, repo_id, issue_number, stage, worktree_path, session_id, status, error_message, started_at, completed_at
-             FROM sessions WHERE repo_id = ?1 AND issue_number = ?2 AND status IN ('running', 'initializing', 'setup')
-             ORDER BY started_at DESC LIMIT 1",
-        )
-        .map_err(|e| format!("Failed to query session: {e}"))?;
+    let sql = format!(
+        "SELECT {SESSION_COLS} FROM sessions WHERE repo_id = ?1 AND issue_number = ?2 AND status IN ('running', 'initializing', 'setup') ORDER BY started_at DESC LIMIT 1"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("Failed to query session: {e}"))?;
 
-    let result = stmt.query_row(params![repo_id, issue_number], |row| {
-        Ok(Session {
-            id: format!("{}", row.get::<_, i64>(0)?),
-            repo_id: row.get(1)?,
-            issue_number: row.get(2)?,
-            stage: row.get(3)?,
-            worktree_path: row.get(4)?,
-            session_id: row.get(5)?,
-            status: row.get(6)?,
-            error_message: row.get(7)?,
-            started_at: row.get(8)?,
-            completed_at: row.get(9)?,
-        })
-    });
+    let result = stmt.query_row(params![repo_id, issue_number], row_to_session);
 
     match result {
         Ok(s) => Ok(Some(s)),
@@ -582,28 +616,12 @@ pub fn get_latest_session(
     repo_id: i64,
     issue_number: i64,
 ) -> Result<Option<Session>, String> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, repo_id, issue_number, stage, worktree_path, session_id, status, error_message, started_at, completed_at
-             FROM sessions WHERE repo_id = ?1 AND issue_number = ?2
-             ORDER BY started_at DESC LIMIT 1",
-        )
-        .map_err(|e| format!("Failed to query session: {e}"))?;
+    let sql = format!(
+        "SELECT {SESSION_COLS} FROM sessions WHERE repo_id = ?1 AND issue_number = ?2 ORDER BY started_at DESC LIMIT 1"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("Failed to query session: {e}"))?;
 
-    let result = stmt.query_row(params![repo_id, issue_number], |row| {
-        Ok(Session {
-            id: format!("{}", row.get::<_, i64>(0)?),
-            repo_id: row.get(1)?,
-            issue_number: row.get(2)?,
-            stage: row.get(3)?,
-            worktree_path: row.get(4)?,
-            session_id: row.get(5)?,
-            status: row.get(6)?,
-            error_message: row.get(7)?,
-            started_at: row.get(8)?,
-            completed_at: row.get(9)?,
-        })
-    });
+    let result = stmt.query_row(params![repo_id, issue_number], row_to_session);
 
     match result {
         Ok(s) => Ok(Some(s)),
@@ -613,27 +631,10 @@ pub fn get_latest_session(
 }
 
 pub fn get_session_by_id(conn: &Connection, session_id: i64) -> Result<Option<Session>, String> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, repo_id, issue_number, stage, worktree_path, session_id, status, error_message, started_at, completed_at
-             FROM sessions WHERE id = ?1",
-        )
-        .map_err(|e| format!("Failed to query session: {e}"))?;
+    let sql = format!("SELECT {SESSION_COLS} FROM sessions WHERE id = ?1");
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("Failed to query session: {e}"))?;
 
-    let result = stmt.query_row(params![session_id], |row| {
-        Ok(Session {
-            id: format!("{}", row.get::<_, i64>(0)?),
-            repo_id: row.get(1)?,
-            issue_number: row.get(2)?,
-            stage: row.get(3)?,
-            worktree_path: row.get(4)?,
-            session_id: row.get(5)?,
-            status: row.get(6)?,
-            error_message: row.get(7)?,
-            started_at: row.get(8)?,
-            completed_at: row.get(9)?,
-        })
-    });
+    let result = stmt.query_row(params![session_id], row_to_session);
 
     match result {
         Ok(s) => Ok(Some(s)),
@@ -643,28 +644,11 @@ pub fn get_session_by_id(conn: &Connection, session_id: i64) -> Result<Option<Se
 }
 
 pub fn get_all_sessions(conn: &Connection) -> Result<Vec<Session>, String> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, repo_id, issue_number, stage, worktree_path, session_id, status, error_message, started_at, completed_at
-             FROM sessions ORDER BY started_at DESC",
-        )
-        .map_err(|e| format!("Failed to query sessions: {e}"))?;
+    let sql = format!("SELECT {SESSION_COLS} FROM sessions WHERE hidden = 0 ORDER BY started_at DESC");
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("Failed to query sessions: {e}"))?;
 
     let rows = stmt
-        .query_map([], |row| {
-            Ok(Session {
-                id: format!("{}", row.get::<_, i64>(0)?),
-                repo_id: row.get(1)?,
-                issue_number: row.get(2)?,
-                stage: row.get(3)?,
-                worktree_path: row.get(4)?,
-                session_id: row.get(5)?,
-                status: row.get(6)?,
-                error_message: row.get(7)?,
-                started_at: row.get(8)?,
-                completed_at: row.get(9)?,
-            })
-        })
+        .query_map([], row_to_session)
         .map_err(|e| format!("Failed to query sessions: {e}"))?;
 
     let mut sessions = Vec::new();
@@ -672,6 +656,41 @@ pub fn get_all_sessions(conn: &Connection) -> Result<Vec<Session>, String> {
         sessions.push(row.map_err(|e| format!("Failed to read session row: {e}"))?);
     }
     Ok(sessions)
+}
+
+pub fn get_hidden_sessions(conn: &Connection, repo_id: i64, issue_number: i64) -> Result<Vec<Session>, String> {
+    let sql = format!(
+        "SELECT {SESSION_COLS} FROM sessions WHERE repo_id = ?1 AND issue_number = ?2 AND hidden = 1 ORDER BY started_at DESC"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("Failed to query hidden sessions: {e}"))?;
+
+    let rows = stmt
+        .query_map(params![repo_id, issue_number], row_to_session)
+        .map_err(|e| format!("Failed to query hidden sessions: {e}"))?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        sessions.push(row.map_err(|e| format!("Failed to read session row: {e}"))?);
+    }
+    Ok(sessions)
+}
+
+pub fn hide_session(conn: &Connection, session_db_id: i64) -> Result<(), String> {
+    conn.execute(
+        "UPDATE sessions SET hidden = 1 WHERE id = ?1",
+        params![session_db_id],
+    )
+    .map_err(|e| format!("Failed to hide session: {e}"))?;
+    Ok(())
+}
+
+pub fn unhide_session(conn: &Connection, session_db_id: i64) -> Result<(), String> {
+    conn.execute(
+        "UPDATE sessions SET hidden = 0 WHERE id = ?1",
+        params![session_db_id],
+    )
+    .map_err(|e| format!("Failed to unhide session: {e}"))?;
+    Ok(())
 }
 
 // ── Session Logs ────────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,9 @@ pub fn run() {
             sessions::session_run_test,
             sessions::session_get_logs,
             sessions::session_cleanup,
+            sessions::session_hide,
+            sessions::session_unhide,
+            sessions::session_list_hidden,
             // Settings
             sessions::settings_get,
             sessions::settings_set,

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -52,6 +52,40 @@ pub async fn session_list(
     Ok(sessions)
 }
 
+#[tauri::command]
+pub async fn session_hide(
+    state: tauri::State<'_, AppState>,
+    session_id: String,
+) -> Result<(), String> {
+    let session_db_id: i64 = session_id
+        .parse()
+        .map_err(|_| "Invalid session ID".to_string())?;
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::hide_session(&db, session_db_id)
+}
+
+#[tauri::command]
+pub async fn session_unhide(
+    state: tauri::State<'_, AppState>,
+    session_id: String,
+) -> Result<(), String> {
+    let session_db_id: i64 = session_id
+        .parse()
+        .map_err(|_| "Invalid session ID".to_string())?;
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::unhide_session(&db, session_db_id)
+}
+
+#[tauri::command]
+pub async fn session_list_hidden(
+    state: tauri::State<'_, AppState>,
+    repo_id: i64,
+    issue_number: i64,
+) -> Result<Vec<Session>, String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::get_hidden_sessions(&db, repo_id, issue_number)
+}
+
 /// Helper to emit a session-status event to the frontend.
 fn emit_session_status(app_handle: &tauri::AppHandle, session: &Session) {
     let _ = app_handle.emit("session-status", session);
@@ -87,6 +121,7 @@ pub async fn session_start(
         error_message: None,
         started_at: chrono::Utc::now().to_rfc3339(),
         completed_at: None,
+        hidden: false,
     };
 
     let session_db_id = {
@@ -190,9 +225,21 @@ pub async fn session_start(
     // Spawn claude in background
     let app = app_handle.clone();
     let wt_path = worktree_path.clone();
+    let owner = repo.owner.clone();
+    let name = repo.name.clone();
     let user_prompt = format!(
-        "GitHub Issue #{issue_number}\n\nAnalyze this issue and the codebase, then write a detailed spec comment."
+        "GitHub Issue #{issue_number} in {owner}/{name}\n\n\
+         Follow the spec process: check for an existing spec in the issue comments, \
+         explore the codebase, and produce or update the spec. \
+         Use `gh` CLI for all GitHub interactions (comments, labels). \
+         The repo is {owner}/{name} and the issue number is {issue_number}."
     );
+
+    let permission_mode = {
+        let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+        let settings = db::get_app_settings(&db)?;
+        if settings.bypass_permissions { "bypassPermissions" } else { "auto" }
+    }.to_string();
 
     tokio::spawn(async move {
         let result = run_claude_session(
@@ -200,7 +247,7 @@ pub async fn session_start(
             &wt_path,
             &spec_prompt,
             &user_prompt,
-            "plan",
+            &permission_mode,
             None,
             session_db_id,
             &app,
@@ -227,20 +274,6 @@ pub async fn session_start(
                         },
                     },
                 );
-
-                // Check if output contains questions
-                let has_questions = res.output.to_lowercase().contains("question")
-                    || res.output.to_lowercase().contains("?");
-
-                if has_questions {
-                    let _ = app.emit(
-                        "session-blocked",
-                        serde_json::json!({
-                            "session_id": session_db_id.to_string(),
-                            "question": res.output,
-                        }),
-                    );
-                }
             }
             Err(e) => {
                 update_status_via_app(&app, session_db_id, "failed", Some(&e));
@@ -313,6 +346,7 @@ pub async fn session_start_implement(
         error_message: None,
         started_at: chrono::Utc::now().to_rfc3339(),
         completed_at: None,
+        hidden: false,
     };
 
     let session_db_id = {
@@ -463,6 +497,7 @@ pub async fn session_start_review(
         error_message: None,
         started_at: chrono::Utc::now().to_rfc3339(),
         completed_at: None,
+        hidden: false,
     };
 
     let session_db_id = {
@@ -1077,7 +1112,6 @@ fn format_tool_summary(name: &str, input: &Value) -> String {
 
 /// Result from running a Claude session, including the captured CLI session ID.
 struct ClaudeSessionResult {
-    output: String,
     /// The Claude CLI session ID captured from the stream output, if available.
     cli_session_id: Option<String>,
 }
@@ -1126,7 +1160,6 @@ async fn run_claude_session(
     let stderr = child.stderr.take();
 
     let mut reader = BufReader::new(stdout).lines();
-    let mut full_output = String::new();
     let mut cli_session_id: Option<String> = None;
 
     while let Some(line) = reader
@@ -1147,9 +1180,6 @@ async fn run_claude_session(
         let entries = parse_stream_json_line(&line);
 
         for (event_type, content) in entries {
-            full_output.push_str(&content);
-            full_output.push('\n');
-
             // Persist log to DB
             insert_log_via_app(app_handle, session_db_id, &event_type, &content);
 
@@ -1193,7 +1223,6 @@ async fn run_claude_session(
     }
 
     Ok(ClaudeSessionResult {
-        output: full_output,
         cli_session_id,
     })
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -50,6 +50,8 @@ pub struct Session {
     pub error_message: Option<String>,
     pub started_at: String,
     pub completed_at: Option<String>,
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/lib/components/CardDetail.svelte
+++ b/src/lib/components/CardDetail.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { selectedIssue } from '$lib/stores/ui';
-	import { sessionsByIssue, sessionLogs } from '$lib/stores/sessions';
+	import { sessions, sessionsByIssue, sessionLogs } from '$lib/stores/sessions';
 	import { repos } from '$lib/stores/repos';
 	import * as backend from '$lib/stores/backend';
 	import type { Session } from '$lib/types';
-	import { X, ExternalLink, Plus, Info } from 'lucide-svelte';
+	import { X, ExternalLink, Plus, Info, History } from 'lucide-svelte';
 	import AgentLog from './AgentLog.svelte';
 	import ChatInput from './ChatInput.svelte';
 
@@ -21,6 +21,10 @@
 	let showDetails = $state(false);
 	let editingBody = $state(false);
 	let bodyDraft = $state('');
+	let confirmHideSessionId: string | null = $state(null);
+	let showHistory = $state(false);
+	let hiddenSessions: Session[] = $state([]);
+	let historyLoading = $state(false);
 
 	// Auto-select the most recent session, or follow new sessions as they appear
 	let prevSessionCount = 0;
@@ -52,12 +56,78 @@
 			showDetails = false;
 			editingBody = false;
 			bodyDraft = issue.body;
+			showHistory = false;
+			confirmHideSessionId = null;
+			hiddenSessions = [];
 		}
 	});
 
 	let activeSession: Session | null = $derived(
 		allSessions.find((s) => s.id === selectedSessionId) ?? null
 	);
+
+	function timeAgo(dateStr: string): string {
+		const now = Date.now();
+		const then = new Date(dateStr).getTime();
+		const diffMs = now - then;
+		const minutes = Math.floor(diffMs / 60000);
+		if (minutes < 1) return 'just now';
+		if (minutes < 60) return `${minutes}m ago`;
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		return `${days}d ago`;
+	}
+
+	function handleHideSession(sessionId: string) {
+		const sess = allSessions.find((s) => s.id === sessionId);
+		if (
+			sess &&
+			(sess.status === 'running' || sess.status === 'initializing' || sess.status === 'setup')
+		) {
+			confirmHideSessionId = sessionId;
+			return;
+		}
+		backend.hideSession(sessionId);
+		sessions.update((all) => all.map((s) => (s.id === sessionId ? { ...s, hidden: true } : s)));
+		if (selectedSessionId === sessionId) {
+			const remaining = allSessions.filter((s) => s.id !== sessionId);
+			selectedSessionId = remaining.length > 0 ? remaining[0].id : null;
+		}
+	}
+
+	async function confirmHideRunningSession() {
+		if (!confirmHideSessionId) return;
+		const idToHide = confirmHideSessionId;
+		await backend.stopSession(idToHide);
+		await backend.hideSession(idToHide);
+		sessions.update((all) => all.map((s) => (s.id === idToHide ? { ...s, hidden: true } : s)));
+		confirmHideSessionId = null;
+		if (selectedSessionId === idToHide) {
+			const remaining = allSessions.filter((s) => s.id !== idToHide);
+			selectedSessionId = remaining.length > 0 ? remaining[0].id : null;
+		}
+	}
+
+	async function handleRestoreSession(sessionId: string) {
+		await backend.unhideSession(sessionId);
+		sessions.update((all) => all.map((s) => (s.id === sessionId ? { ...s, hidden: false } : s)));
+		hiddenSessions = hiddenSessions.filter((s) => s.id !== sessionId);
+		selectedSessionId = sessionId;
+	}
+
+	async function toggleHistory() {
+		showHistory = !showHistory;
+		if (showHistory && repoConfig && issue) {
+			historyLoading = true;
+			try {
+				hiddenSessions = await backend.listHiddenSessions(repoConfig.id, issue.number);
+			} catch {
+				hiddenSessions = [];
+			}
+			historyLoading = false;
+		}
+	}
 
 	function close() {
 		selectedIssue.set(null);
@@ -277,40 +347,106 @@
 			{/if}
 
 			<!-- Session tabs -->
-			{#if allSessions.length > 0}
-				<div class="shrink-0 px-4 py-2 border-b border-border flex items-center gap-2">
-					<div class="flex gap-1 flex-1 overflow-x-auto">
-						{#each allSessions as sess (sess.id)}
-							<button
-								class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-colors
-									{sess.id === selectedSessionId
-									? 'bg-muted text-foreground'
-									: 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
-								onclick={() => {
-									selectedSessionId = sess.id;
-								}}
-							>
-								<span class="h-2 w-2 rounded-full shrink-0 {statusDotClass(sess.status)}"></span>
-								{sess.stage}{allSessions.filter((s) => s.stage === sess.stage).length > 1
-									? ` #${allSessions.filter((s) => s.stage === sess.stage).indexOf(sess) + 1}`
-									: ''}
-								{#if sess.id === selectedSessionId}
-									<span class="text-muted-foreground font-normal ml-0.5">
-										{elapsedTime(sess.started_at, sess.completed_at)}
+				<div class="shrink-0 border-b border-border">
+					<div class="px-4 py-2 flex items-center gap-2">
+						<div class="flex gap-1 flex-1 overflow-x-auto">
+							{#each allSessions as sess (sess.id)}
+								<button
+									class="group flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-colors
+										{sess.id === selectedSessionId
+										? 'bg-muted text-foreground'
+										: 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
+									onclick={() => {
+										selectedSessionId = sess.id;
+									}}
+								>
+									<span class="h-2 w-2 rounded-full shrink-0 {statusDotClass(sess.status)}"></span>
+									{sess.stage}{allSessions.filter((s) => s.stage === sess.stage).length > 1
+										? ` #${allSessions.filter((s) => s.stage === sess.stage).indexOf(sess) + 1}`
+										: ''}
+									{#if sess.id === selectedSessionId}
+										<span class="text-muted-foreground font-normal ml-0.5">
+											{elapsedTime(sess.started_at, sess.completed_at)}
+										</span>
+									{/if}
+									<span
+										role="button"
+										tabindex="0"
+										class="ml-0.5 p-0.5 rounded hover:bg-background/50 opacity-0 group-hover:opacity-100 transition-opacity"
+										onclick={(e) => { e.stopPropagation(); handleHideSession(sess.id); }}
+										onkeydown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); handleHideSession(sess.id); } }}
+										title="Close tab"
+									>
+										<X class="h-3 w-3" />
 									</span>
-								{/if}
+								</button>
+							{/each}
+						</div>
+						<button
+							class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+							onclick={handleNewSession}
+							title="New session"
+						>
+							<Plus class="h-3.5 w-3.5" />
+						</button>
+						<div class="relative">
+							<button
+								class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0 {showHistory ? 'bg-muted text-foreground' : ''}"
+								onclick={toggleHistory}
+								title="Session history"
+							>
+								<History class="h-3.5 w-3.5" />
 							</button>
-						{/each}
+
+							<!-- History popover -->
+							{#if showHistory}
+								<div class="absolute right-0 top-full mt-1 z-50 w-64 rounded-lg border border-border bg-popover shadow-lg overflow-hidden">
+									{#if historyLoading}
+										<div class="px-3 py-2 text-xs text-muted-foreground">Loading...</div>
+									{:else if hiddenSessions.length === 0}
+										<div class="px-3 py-2 text-xs text-muted-foreground">No closed sessions.</div>
+									{:else}
+										<div class="max-h-48 overflow-y-auto">
+											{#each hiddenSessions as sess (sess.id)}
+												<div class="flex items-center gap-2 px-3 py-1.5 hover:bg-muted/50 transition-colors">
+													<span class="h-2 w-2 rounded-full shrink-0 {statusDotClass(sess.status)}"></span>
+													<span class="text-xs font-medium text-foreground flex-1 truncate">{sess.stage}</span>
+													<span class="text-[10px] text-muted-foreground whitespace-nowrap">{timeAgo(sess.started_at)}</span>
+													<button
+														class="p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+														onclick={() => handleRestoreSession(sess.id)}
+														title="Restore session"
+													>
+														<History class="h-3 w-3" />
+													</button>
+												</div>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/if}
+						</div>
 					</div>
-					<button
-						class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
-						onclick={handleNewSession}
-						title="New session"
-					>
-						<Plus class="h-3.5 w-3.5" />
-					</button>
+
+					<!-- Confirmation bar for closing running sessions -->
+					{#if confirmHideSessionId}
+						<div class="border-t border-border bg-red-500/5 px-4 py-3 flex items-center gap-3">
+							<span class="text-xs text-foreground flex-1">Stop running agent and close tab?</span>
+							<button
+								class="px-2.5 py-1 rounded-md text-xs font-medium bg-red-600 hover:bg-red-500 text-white transition-colors"
+								onclick={confirmHideRunningSession}
+							>
+								Stop & close
+							</button>
+							<button
+								class="px-2.5 py-1 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+								onclick={() => { confirmHideSessionId = null; }}
+							>
+								Cancel
+							</button>
+						</div>
+					{/if}
 				</div>
-			{/if}
 
 			<!-- Error banner -->
 			{#if activeSession?.error_message}
@@ -322,13 +458,13 @@
 			{/if}
 
 			<!-- Agent log -->
-			{#if allSessions.length > 0 && activeSession}
+			{#if activeSession}
 				<div class="flex-1 min-h-0 flex flex-col overflow-hidden">
 					<AgentLog sessionId={activeSession.id} />
 				</div>
 			{:else}
 				<div class="flex-1 flex items-center justify-center">
-					<p class="text-sm text-muted-foreground">No sessions yet.</p>
+					<p class="text-sm text-muted-foreground">Send a message to start a new session.</p>
 				</div>
 			{/if}
 

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -31,7 +31,7 @@
 			session?.status === 'initializing' ||
 			session?.status === 'setup'
 	);
-	let canSend = $derived(!isRunning && input.trim().length > 0 && session !== null);
+	let canSend = $derived(!isRunning && input.trim().length > 0);
 
 	const slashCommands = [
 		{ name: 'test', description: 'Run tests for this session' },
@@ -198,11 +198,15 @@
 	}
 
 	async function handleSend() {
-		if (!canSend || !session) return;
+		if (!canSend) return;
 		const message = input.trim();
 		input = '';
 		autoResize();
-		await backend.respondToSession(session.id, message);
+		if (session) {
+			await backend.respondToSession(session.id, message);
+		} else {
+			onNewSession();
+		}
 	}
 
 	async function handleStop() {

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -269,6 +269,19 @@ export async function setSelectedRepoId(repoId: number): Promise<void> {
 	return invoke('set_selected_repo_id', { repoId });
 }
 
+// Session visibility
+export async function hideSession(sessionId: string): Promise<void> {
+	return invoke('session_hide', { sessionId });
+}
+
+export async function unhideSession(sessionId: string): Promise<void> {
+	return invoke('session_unhide', { sessionId });
+}
+
+export async function listHiddenSessions(repoId: number, issueNumber: number): Promise<Session[]> {
+	return invoke('session_list_hidden', { repoId, issueNumber });
+}
+
 // Session Files
 export async function listSessionFiles(sessionId: string): Promise<string[]> {
 	return invoke('session_list_files', { sessionId });

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -7,6 +7,7 @@ export const sessionLogs = writable<Map<string, SessionLogEntry[]>>(new Map());
 export const sessionByIssue = derived(sessions, ($sessions) => {
 	const map = new Map<string, Session>();
 	for (const session of $sessions) {
+		if (session.hidden) continue;
 		const key = `${session.repo_id}:${session.issue_number}`;
 		const existing = map.get(key);
 		// Keep the most recent session per issue
@@ -17,10 +18,11 @@ export const sessionByIssue = derived(sessions, ($sessions) => {
 	return map;
 });
 
-/** All sessions for a given issue, sorted newest first. */
+/** All visible (non-hidden) sessions for a given issue, sorted newest first. */
 export const sessionsByIssue = derived(sessions, ($sessions) => {
 	const map = new Map<string, Session[]>();
 	for (const session of $sessions) {
+		if (session.hidden) continue;
 		const key = `${session.repo_id}:${session.issue_number}`;
 		const list = map.get(key) ?? [];
 		list.push(session);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -42,6 +42,7 @@ export interface Session {
 	error_message: string | null;
 	started_at: string;
 	completed_at: string | null;
+	hidden: boolean;
 }
 
 export interface SessionLogEntry {


### PR DESCRIPTION
## Summary
- Adds a chat input component for conversational interaction with agent sessions, supporting message send, slash commands, and @-file references
- Session tabs can be closed via X button (with confirmation for running agents); closed sessions move to a history popover for later restoration
- Session resume (`session_respond`) now reuses the existing session row instead of creating a duplicate tab
- Spec stage updated to use `gh` CLI for checking existing specs, posting spec comments, managing labels (`autodev:blocked`, `autodev:in-progress`), and using `auto` permission mode instead of read-only `plan`
- Fixes pre-existing `@types/node` missing type error in vite.config.ts

## Test plan
- [ ] Open an issue card, verify chat input appears and accepts messages
- [ ] Send a message to a completed session — verify it resumes in the same tab (no duplicate)
- [ ] Close a non-running session tab via X — verify it disappears immediately
- [ ] Close a running session tab — verify confirmation bar appears, "Stop & close" works
- [ ] Click history icon — verify popover shows closed sessions with restore button
- [ ] Restore a session from history — verify it reappears as an active tab
- [ ] Close all tabs — verify empty state with "Send a message to start a new session" and functional input
- [ ] Start a spec session — verify it uses `gh` CLI to check for existing specs and post comments