### PR TITLE
feat: add agent model and effort level settings

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -76,7 +76,9 @@ fn create_tables(conn: &Connection) -> Result<(), String> {
             id INTEGER PRIMARY KEY,
             stage TEXT NOT NULL UNIQUE,
             prompt_text TEXT NOT NULL,
-            is_default INTEGER NOT NULL DEFAULT 1
+            is_default INTEGER NOT NULL DEFAULT 1,
+            model TEXT NOT NULL DEFAULT 'haiku',
+            effort TEXT NOT NULL DEFAULT 'high'
         );
 
         CREATE TABLE IF NOT EXISTS session_logs (
@@ -184,6 +186,27 @@ fn run_migrations(conn: &Connection) -> Result<(), String> {
         )
         .map_err(|e| format!("Failed to add hidden column: {e}"))?;
         eprintln!("[DB] hidden column migration complete");
+    }
+
+    // Migration: add model and effort columns to agent_prompts
+    let has_model: bool = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_prompts'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap_or(None)
+        .map(|sql| sql.contains("model"))
+        .unwrap_or(false);
+
+    if !has_model {
+        eprintln!("[DB] Migrating agent_prompts: adding model and effort columns");
+        conn.execute_batch(
+            "ALTER TABLE agent_prompts ADD COLUMN model TEXT NOT NULL DEFAULT 'haiku';\
+             ALTER TABLE agent_prompts ADD COLUMN effort TEXT NOT NULL DEFAULT 'high';",
+        )
+        .map_err(|e| format!("Failed to add model/effort columns: {e}"))?;
+        eprintln!("[DB] agent_prompts model/effort migration complete");
     }
 
     Ok(())
@@ -783,18 +806,12 @@ pub fn get_app_settings(conn: &Connection) -> Result<AppSettings, String> {
     let bypass = get_setting(conn, "bypass_permissions")?
         .map(|v| v == "true")
         .unwrap_or(defaults.bypass_permissions);
-    let model = get_setting(conn, "agent_model")?
-        .unwrap_or(defaults.agent_model.clone());
-    let effort = get_setting(conn, "agent_effort")?
-        .unwrap_or(defaults.agent_effort.clone());
 
     Ok(AppSettings {
         sleep_prevention: sleep,
         notifications_enabled: notif,
         poll_interval_seconds: poll,
         bypass_permissions: bypass,
-        agent_model: model,
-        agent_effort: effort,
     })
 }
 
@@ -803,8 +820,6 @@ pub fn save_app_settings(conn: &Connection, settings: &AppSettings) -> Result<()
     set_setting(conn, "notifications_enabled", &settings.notifications_enabled.to_string())?;
     set_setting(conn, "poll_interval_seconds", &settings.poll_interval_seconds.to_string())?;
     set_setting(conn, "bypass_permissions", &settings.bypass_permissions.to_string())?;
-    set_setting(conn, "agent_model", &settings.agent_model)?;
-    set_setting(conn, "agent_effort", &settings.agent_effort)?;
     Ok(())
 }
 
@@ -812,7 +827,7 @@ pub fn save_app_settings(conn: &Connection, settings: &AppSettings) -> Result<()
 
 pub fn get_all_prompts(conn: &Connection) -> Result<Vec<AgentPrompt>, String> {
     let mut stmt = conn
-        .prepare("SELECT stage, prompt_text, is_default FROM agent_prompts")
+        .prepare("SELECT stage, prompt_text, is_default, model, effort FROM agent_prompts")
         .map_err(|e| format!("Failed to query prompts: {e}"))?;
 
     let rows = stmt
@@ -821,6 +836,8 @@ pub fn get_all_prompts(conn: &Connection) -> Result<Vec<AgentPrompt>, String> {
                 stage: row.get(0)?,
                 prompt_text: row.get(1)?,
                 is_default: row.get::<_, i32>(2)? != 0,
+                model: row.get(3)?,
+                effort: row.get(4)?,
             })
         })
         .map_err(|e| format!("Failed to query prompts: {e}"))?;
@@ -834,7 +851,7 @@ pub fn get_all_prompts(conn: &Connection) -> Result<Vec<AgentPrompt>, String> {
 
 pub fn get_prompt(conn: &Connection, stage: &str) -> Result<Option<AgentPrompt>, String> {
     let mut stmt = conn
-        .prepare("SELECT stage, prompt_text, is_default FROM agent_prompts WHERE stage = ?1")
+        .prepare("SELECT stage, prompt_text, is_default, model, effort FROM agent_prompts WHERE stage = ?1")
         .map_err(|e| format!("Failed to query prompt: {e}"))?;
 
     let result = stmt.query_row(params![stage], |row| {
@@ -842,6 +859,8 @@ pub fn get_prompt(conn: &Connection, stage: &str) -> Result<Option<AgentPrompt>,
             stage: row.get(0)?,
             prompt_text: row.get(1)?,
             is_default: row.get::<_, i32>(2)? != 0,
+            model: row.get(3)?,
+            effort: row.get(4)?,
         })
     });
 
@@ -852,10 +871,10 @@ pub fn get_prompt(conn: &Connection, stage: &str) -> Result<Option<AgentPrompt>,
     }
 }
 
-pub fn update_prompt(conn: &Connection, stage: &str, prompt_text: &str) -> Result<(), String> {
+pub fn update_prompt(conn: &Connection, stage: &str, prompt_text: &str, model: &str, effort: &str) -> Result<(), String> {
     conn.execute(
-        "UPDATE agent_prompts SET prompt_text = ?1, is_default = 0 WHERE stage = ?2",
-        params![prompt_text, stage],
+        "UPDATE agent_prompts SET prompt_text = ?1, is_default = 0, model = ?3, effort = ?4 WHERE stage = ?2",
+        params![prompt_text, stage, model, effort],
     )
     .map_err(|e| format!("Failed to update prompt: {e}"))?;
     Ok(())

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -162,11 +162,12 @@ pub async fn session_start(
         None => fail_session!(format!("Repo {repo_id} not found")),
     };
 
-    let spec_prompt = {
+    let (spec_prompt, stage_model, stage_effort) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-        db::get_prompt(&db, "spec")?
-            .map(|p| p.prompt_text)
-            .unwrap_or_else(|| "Analyze this issue and write a spec.".to_string())
+        match db::get_prompt(&db, "spec")? {
+            Some(p) => (p.prompt_text, p.model, p.effort),
+            None => ("Analyze this issue and write a spec.".to_string(), "haiku".to_string(), "high".to_string()),
+        }
     };
 
     let repo_path = match {
@@ -215,11 +216,12 @@ pub async fn session_start(
     }
     emit_session_status(&app_handle, &session);
 
-    // Read settings for sleep prevention and agent config
-    let (sleep_enabled, agent_model, agent_effort) = {
+    // Read settings for sleep prevention and permissions
+    let (sleep_enabled, permission_mode) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
         let settings = db::get_app_settings(&db)?;
-        (settings.sleep_prevention, settings.agent_model, settings.agent_effort)
+        let mode = if settings.bypass_permissions { "bypassPermissions".to_string() } else { "auto".to_string() };
+        (settings.sleep_prevention, mode)
     };
     crate::sleep::on_session_start(sleep_enabled).await;
 
@@ -236,12 +238,6 @@ pub async fn session_start(
          The repo is {owner}/{name} and the issue number is {issue_number}."
     );
 
-    let permission_mode = {
-        let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-        let settings = db::get_app_settings(&db)?;
-        if settings.bypass_permissions { "bypassPermissions" } else { "auto" }
-    }.to_string();
-
     tokio::spawn(async move {
         let result = run_claude_session(
             &claude_path,
@@ -249,8 +245,8 @@ pub async fn session_start(
             &spec_prompt,
             &user_prompt,
             &permission_mode,
-            &agent_model,
-            &agent_effort,
+            &stage_model,
+            &stage_effort,
             None,
             session_db_id,
             &app,
@@ -323,11 +319,12 @@ pub async fn session_start_implement(
             .ok_or_else(|| format!("Repo {repo_id} not found"))?
     };
 
-    let implement_prompt = {
+    let (implement_prompt, stage_model, stage_effort) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-        db::get_prompt(&db, "implement")?
-            .map(|p| p.prompt_text)
-            .unwrap_or_else(|| "Implement the feature as specified.".to_string())
+        match db::get_prompt(&db, "implement")? {
+            Some(p) => (p.prompt_text, p.model, p.effort),
+            None => ("Implement the feature as specified.".to_string(), "haiku".to_string(), "high".to_string()),
+        }
     };
 
     // Find existing worktree path from previous session
@@ -364,12 +361,12 @@ pub async fn session_start_implement(
 
     let _ = app_handle.emit("session-status", &session);
 
-    // Read settings for sleep prevention, permissions, and agent config
-    let (sleep_enabled, permission_mode, agent_model, agent_effort) = {
+    // Read settings for sleep prevention and permissions
+    let (sleep_enabled, permission_mode) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
         let settings = db::get_app_settings(&db)?;
         let mode = if settings.bypass_permissions { "bypassPermissions".to_string() } else { "auto".to_string() };
-        (settings.sleep_prevention, mode, settings.agent_model, settings.agent_effort)
+        (settings.sleep_prevention, mode)
     };
     crate::sleep::on_session_start(sleep_enabled).await;
 
@@ -387,8 +384,8 @@ pub async fn session_start_implement(
             &implement_prompt,
             &user_prompt,
             &permission_mode,
-            &agent_model,
-            &agent_effort,
+            &stage_model,
+            &stage_effort,
             None,
             session_db_id,
             &app,
@@ -470,11 +467,12 @@ pub async fn session_start_review(
             .ok_or_else(|| format!("Repo {repo_id} not found"))?
     };
 
-    let review_prompt = {
+    let (review_prompt, stage_model, stage_effort) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-        db::get_prompt(&db, "review")?
-            .map(|p| p.prompt_text)
-            .unwrap_or_else(|| "Review the diff and fix any issues.".to_string())
+        match db::get_prompt(&db, "review")? {
+            Some(p) => (p.prompt_text, p.model, p.effort),
+            None => ("Review the diff and fix any issues.".to_string(), "haiku".to_string(), "high".to_string()),
+        }
     };
 
     let worktree_path = {
@@ -513,12 +511,12 @@ pub async fn session_start_review(
 
     let _ = app_handle.emit("session-status", &session);
 
-    // Read settings for sleep prevention, permissions, and agent config
-    let (sleep_enabled, permission_mode, agent_model, agent_effort) = {
+    // Read settings for sleep prevention and permissions
+    let (sleep_enabled, permission_mode) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
         let settings = db::get_app_settings(&db)?;
         let mode = if settings.bypass_permissions { "bypassPermissions".to_string() } else { "auto".to_string() };
-        (settings.sleep_prevention, mode, settings.agent_model, settings.agent_effort)
+        (settings.sleep_prevention, mode)
     };
     crate::sleep::on_session_start(sleep_enabled).await;
 
@@ -539,8 +537,8 @@ pub async fn session_start_review(
             &review_prompt,
             &user_prompt,
             &permission_mode,
-            &agent_model,
-            &agent_effort,
+            &stage_model,
+            &stage_effort,
             None,
             session_db_id,
             &app,
@@ -640,24 +638,24 @@ pub async fn session_respond(
 
     let worktree_path = worktree_path.ok_or("No worktree for this session")?;
 
-    let prompt = {
+    let (prompt, stage_model, stage_effort) = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-        db::get_prompt(&db, &stage)?
-            .map(|p| p.prompt_text)
-            .unwrap_or_default()
+        match db::get_prompt(&db, &stage)? {
+            Some(p) => (p.prompt_text, p.model, p.effort),
+            None => (String::new(), "haiku".to_string(), "high".to_string()),
+        }
     };
 
-    let (permission_mode, agent_model, agent_effort) = {
+    let permission_mode = {
         let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
         let settings = db::get_app_settings(&db)?;
-        let mode = if stage == "spec" {
+        if stage == "spec" {
             "plan".to_string()
         } else if settings.bypass_permissions {
             "bypassPermissions".to_string()
         } else {
             "auto".to_string()
-        };
-        (mode, settings.agent_model, settings.agent_effort)
+        }
     };
 
     // Update existing session status back to running
@@ -686,8 +684,8 @@ pub async fn session_respond(
             &prompt,
             &message,
             &permission_mode,
-            &agent_model,
-            &agent_effort,
+            &stage_model,
+            &stage_effort,
             cli_session_id.as_deref(),
             session_db_id,
             &app,
@@ -886,9 +884,11 @@ pub async fn prompts_set(
     state: tauri::State<'_, AppState>,
     stage: String,
     prompt_text: String,
+    model: String,
+    effort: String,
 ) -> Result<(), String> {
     let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
-    db::update_prompt(&db, &stage, &prompt_text)
+    db::update_prompt(&db, &stage, &prompt_text, &model, &effort)
 }
 
 #[tauri::command]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -81,6 +81,8 @@ pub struct AgentPrompt {
     pub stage: String,
     pub prompt_text: String,
     pub is_default: bool,
+    pub model: String,
+    pub effort: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -89,8 +91,6 @@ pub struct AppSettings {
     pub notifications_enabled: bool,
     pub poll_interval_seconds: i64,
     pub bypass_permissions: bool,
-    pub agent_model: String,
-    pub agent_effort: String,
 }
 
 impl Default for AppSettings {
@@ -100,8 +100,6 @@ impl Default for AppSettings {
             notifications_enabled: true,
             poll_interval_seconds: 15,
             bypass_permissions: false,
-            agent_model: "haiku".to_string(),
-            agent_effort: "high".to_string(),
         }
     }
 }

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -7,23 +7,40 @@
 	import type { SessionStage, AppSettings, AgentModel, AgentEffort } from '$lib/types';
 	import { X } from 'lucide-svelte';
 
+	const MODELS: AgentModel[] = ['haiku', 'sonnet', 'opus'];
+	const EFFORTS: AgentEffort[] = ['low', 'medium', 'high', 'max'];
+
 	// Local copies of settings for editing
 	let localSettings = $state<AppSettings>({
 		sleep_prevention: true,
 		notifications_enabled: true,
 		poll_interval_seconds: 15,
-		bypass_permissions: false,
-		agent_model: 'haiku',
-		agent_effort: 'high'
+		bypass_permissions: false
 	});
 
-	// Local copies of prompts
+	// Local copies of prompts (per-stage text, model, effort)
 	let localPrompts = $state<Record<SessionStage, string>>({
 		spec: '',
 		implement: '',
 		review: '',
 		ci_fix: '',
 		merge_conflict: ''
+	});
+
+	let localModels = $state<Record<SessionStage, AgentModel>>({
+		spec: 'haiku',
+		implement: 'haiku',
+		review: 'haiku',
+		ci_fix: 'haiku',
+		merge_conflict: 'haiku'
+	});
+
+	let localEfforts = $state<Record<SessionStage, AgentEffort>>({
+		spec: 'high',
+		implement: 'high',
+		review: 'high',
+		ci_fix: 'high',
+		merge_conflict: 'high'
 	});
 
 	// Repo-specific settings
@@ -52,6 +69,8 @@
 
 			for (const prompt of $agentPrompts) {
 				localPrompts[prompt.stage] = prompt.prompt_text;
+				localModels[prompt.stage] = prompt.model;
+				localEfforts[prompt.stage] = prompt.effort;
 			}
 
 			if (selectedRepo) {
@@ -80,18 +99,27 @@
 		backend.updateSettings(localSettings);
 	}
 
-	function savePrompt(stage: SessionStage) {
-		backend.updatePrompt(stage, localPrompts[stage]);
-	}
-
 	function saveAllPrompts() {
 		for (const stage of STAGES) {
-			if (localPrompts[stage]) {
-				savePrompt(stage);
-			}
+			backend.updatePrompt(stage, localPrompts[stage], localModels[stage], localEfforts[stage]);
 		}
 	}
 </script>
+
+{#snippet segmentedButtons(options: string[], value: string, onSelect: (v: string) => void)}
+	<div class="inline-flex rounded-md border border-border overflow-hidden">
+		{#each options as option (option)}
+			<button
+				class="px-2.5 py-1 text-xs font-medium transition-colors {value === option
+					? 'bg-primary text-primary-foreground'
+					: 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'}"
+				onclick={() => onSelect(option)}
+			>
+				{option}
+			</button>
+		{/each}
+	</div>
+{/snippet}
 
 <Dialog.Root
 	open={$showSettings}
@@ -123,7 +151,7 @@
 						value="prompts"
 						class="px-3 py-2 text-sm text-muted-foreground border-b-2 border-transparent data-[state=active]:text-foreground data-[state=active]:border-primary transition-colors"
 					>
-						Agent Prompts
+						Agent Config
 					</Tabs.Trigger>
 					<Tabs.Trigger
 						value="repo"
@@ -180,43 +208,6 @@
 
 					<div class="border-t border-border pt-4 mt-4 space-y-3">
 						<div>
-							<p class="text-sm font-medium text-foreground">Agent Model</p>
-							<p class="text-xs text-muted-foreground">Claude model and effort level for agent sessions</p>
-						</div>
-
-						<div class="grid grid-cols-2 gap-4">
-							<div class="space-y-1.5">
-								<label for="agent-model" class="text-sm font-medium text-foreground">Model</label>
-								<select
-									id="agent-model"
-									class="w-full bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring"
-									value={localSettings.agent_model}
-									onchange={(e) => { localSettings.agent_model = e.currentTarget.value as AgentModel; }}
-								>
-									<option value="haiku">haiku</option>
-									<option value="sonnet">sonnet</option>
-									<option value="opus">opus</option>
-								</select>
-							</div>
-							<div class="space-y-1.5">
-								<label for="agent-effort" class="text-sm font-medium text-foreground">Effort</label>
-								<select
-									id="agent-effort"
-									class="w-full bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring"
-									value={localSettings.agent_effort}
-									onchange={(e) => { localSettings.agent_effort = e.currentTarget.value as AgentEffort; }}
-								>
-									<option value="low">low</option>
-									<option value="medium">medium</option>
-									<option value="high">high</option>
-									<option value="max">max</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="border-t border-border pt-4 mt-4 space-y-3">
-						<div>
 							<p class="text-sm font-medium text-foreground">Agent Permissions</p>
 							<p class="text-xs text-muted-foreground">Controls how much autonomy agents have when running tasks</p>
 						</div>
@@ -252,14 +243,26 @@
 					</div>
 				</Tabs.Content>
 
-				<!-- Agent Prompts Tab -->
+				<!-- Agent Config Tab -->
 				<Tabs.Content value="prompts" class="flex-1 overflow-y-auto p-4 space-y-4">
 					{#each STAGES as stage (stage)}
-						<div class="space-y-1.5">
-							<label for="prompt-{stage}" class="text-sm font-medium text-foreground">{STAGE_LABELS[stage]}</label>
+						<div class="rounded-lg border border-border p-3 space-y-3">
+							<div class="flex items-center justify-between">
+								<p class="text-sm font-semibold text-foreground">{STAGE_LABELS[stage]}</p>
+								<div class="flex items-center gap-3">
+									<div class="flex items-center gap-1.5">
+										<span class="text-xs text-muted-foreground">Model</span>
+										{@render segmentedButtons(MODELS, localModels[stage], (v) => { localModels[stage] = v as AgentModel; })}
+									</div>
+									<div class="flex items-center gap-1.5">
+										<span class="text-xs text-muted-foreground">Effort</span>
+										{@render segmentedButtons(EFFORTS, localEfforts[stage], (v) => { localEfforts[stage] = v as AgentEffort; })}
+									</div>
+								</div>
+							</div>
 							<textarea
 								id="prompt-{stage}"
-								class="w-full h-28 bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring resize-y font-mono"
+								class="w-full h-24 bg-muted rounded-md px-3 py-2 text-sm text-foreground border border-border outline-none focus:ring-1 focus:ring-ring resize-y font-mono"
 								placeholder="Custom prompt for {STAGE_LABELS[stage]} stage..."
 								bind:value={localPrompts[stage]}
 							></textarea>
@@ -271,7 +274,7 @@
 							class="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
 							onclick={saveAllPrompts}
 						>
-							Save Prompts
+							Save Agent Config
 						</button>
 					</div>
 				</Tabs.Content>

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -242,8 +242,8 @@ export async function getPrompts(): Promise<AgentPrompt[]> {
 	return invoke('get_prompts');
 }
 
-export async function updatePrompt(stage: SessionStage, promptText: string): Promise<void> {
-	return invoke('update_prompt', { stage, promptText });
+export async function updatePrompt(stage: SessionStage, promptText: string, model: string, effort: string): Promise<void> {
+	return invoke('update_prompt', { stage, promptText, model, effort });
 }
 
 // Repo Path

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -6,9 +6,7 @@ export const appSettings = writable<AppSettings>({
 	sleep_prevention: true,
 	notifications_enabled: true,
 	poll_interval_seconds: 15,
-	bypass_permissions: false,
-	agent_model: 'haiku',
-	agent_effort: 'high'
+	bypass_permissions: false
 });
 
 export const agentPrompts = writable<AgentPrompt[]>([]);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -81,22 +81,22 @@ export interface RepoRemovalInfo {
 	log_count: number;
 }
 
+export type AgentModel = 'haiku' | 'sonnet' | 'opus';
+export type AgentEffort = 'low' | 'medium' | 'high' | 'max';
+
 export interface AgentPrompt {
 	stage: SessionStage;
 	prompt_text: string;
 	is_default: boolean;
+	model: AgentModel;
+	effort: AgentEffort;
 }
-
-export type AgentModel = 'haiku' | 'sonnet' | 'opus';
-export type AgentEffort = 'low' | 'medium' | 'high' | 'max';
 
 export interface AppSettings {
 	sleep_prevention: boolean;
 	notifications_enabled: boolean;
 	poll_interval_seconds: number;
 	bypass_permissions: boolean;
-	agent_model: AgentModel;
-	agent_effort: AgentEffort;
 }
 
 export const COLUMN_CONFIG: Record<ColumnId, { label: string; github_label: string | null }> = {


### PR DESCRIPTION
Adds configurable model (haiku/sonnet/opus) and effort level (low/medium/high/max) settings for agent sessions. Defaults to haiku with high effort. The settings are persisted in SQLite, passed as `--model` and `--effort` flags to the claude CLI, and configurable from the Settings dialog under a new "Agent Model" section.