### PR TITLE
feat: lazy chat tabs with phase selection buttons

### DIFF
--- a/src/lib/components/CardDetail.svelte
+++ b/src/lib/components/CardDetail.svelte
@@ -3,8 +3,8 @@
 	import { sessions, sessionsByIssue, sessionLogs } from '$lib/stores/sessions';
 	import { repos } from '$lib/stores/repos';
 	import * as backend from '$lib/stores/backend';
-	import type { Session } from '$lib/types';
-	import { X, ExternalLink, Plus, Info, History } from 'lucide-svelte';
+	import type { Session, SessionStage } from '$lib/types';
+	import { X, ExternalLink, Plus, Info, History, FileText, Code, Eye } from 'lucide-svelte';
 	import AgentLog from './AgentLog.svelte';
 	import ChatInput from './ChatInput.svelte';
 
@@ -18,6 +18,7 @@
 	let allSessions = $derived(sessionKey ? $sessionsByIssue.get(sessionKey) ?? [] : []);
 
 	let selectedSessionId: string | null = $state(null);
+	let pendingNewTab = $state(false);
 	let showDetails = $state(false);
 	let editingBody = $state(false);
 	let bodyDraft = $state('');
@@ -29,6 +30,11 @@
 	// Auto-select the most recent session, or follow new sessions as they appear
 	let prevSessionCount = 0;
 	$effect(() => {
+		if (pendingNewTab) {
+			// Don't auto-select when user has a pending new tab open
+			prevSessionCount = allSessions.length;
+			return;
+		}
 		if (allSessions.length > 0) {
 			const ids = new Set(allSessions.map((s) => s.id));
 			if (!selectedSessionId || !ids.has(selectedSessionId)) {
@@ -53,6 +59,7 @@
 	$effect(() => {
 		if (issue) {
 			selectedSessionId = null;
+			pendingNewTab = false;
 			showDetails = false;
 			editingBody = false;
 			bodyDraft = issue.body;
@@ -187,10 +194,29 @@
 		}
 	}
 
-	function handleNewSession() {
-		if (repoConfig && issue) {
-			backend.startSession(repoConfig.id, issue.number);
+	function handleNewTab() {
+		pendingNewTab = true;
+		selectedSessionId = null;
+	}
+
+	function handleStartPhase(stage: SessionStage) {
+		if (!repoConfig || !issue) return;
+		pendingNewTab = false;
+		switch (stage) {
+			case 'spec':
+				backend.startSession(repoConfig.id, issue.number);
+				break;
+			case 'implement':
+				backend.startImplementSession(repoConfig.id, issue.number);
+				break;
+			case 'review':
+				backend.startReviewSession(repoConfig.id, issue.number);
+				break;
 		}
+	}
+
+	function handleNewSession() {
+		handleStartPhase('spec');
 	}
 
 	let copied = $state(false);
@@ -353,11 +379,12 @@
 							{#each allSessions as sess (sess.id)}
 								<button
 									class="group flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-colors
-										{sess.id === selectedSessionId
+										{sess.id === selectedSessionId && !pendingNewTab
 										? 'bg-muted text-foreground'
 										: 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
 									onclick={() => {
 										selectedSessionId = sess.id;
+										pendingNewTab = false;
 									}}
 								>
 									<span class="h-2 w-2 rounded-full shrink-0 {statusDotClass(sess.status)}"></span>
@@ -381,10 +408,28 @@
 									</span>
 								</button>
 							{/each}
+							{#if pendingNewTab}
+								<button
+									class="group flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-colors bg-muted text-foreground"
+								>
+									<span class="h-2 w-2 rounded-full shrink-0 bg-muted-foreground"></span>
+									new
+									<span
+										role="button"
+										tabindex="0"
+										class="ml-0.5 p-0.5 rounded hover:bg-background/50 opacity-0 group-hover:opacity-100 transition-opacity"
+										onclick={(e) => { e.stopPropagation(); pendingNewTab = false; if (allSessions.length > 0) selectedSessionId = allSessions[0].id; }}
+										onkeydown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); pendingNewTab = false; if (allSessions.length > 0) selectedSessionId = allSessions[0].id; } }}
+										title="Close tab"
+									>
+										<X class="h-3 w-3" />
+									</span>
+								</button>
+							{/if}
 						</div>
 						<button
 							class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
-							onclick={handleNewSession}
+							onclick={handleNewTab}
 							title="New session"
 						>
 							<Plus class="h-3.5 w-3.5" />
@@ -462,9 +507,63 @@
 				<div class="flex-1 min-h-0 flex flex-col overflow-hidden">
 					<AgentLog sessionId={activeSession.id} />
 				</div>
+			{:else if pendingNewTab}
+				<div class="flex-1 flex items-center justify-center">
+					<div class="flex flex-col items-center gap-4">
+						<p class="text-sm text-muted-foreground">Start a phase or send a message</p>
+						<div class="flex gap-2">
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('spec')}
+							>
+								<FileText class="h-4 w-4 text-blue-400" />
+								Spec
+							</button>
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('implement')}
+							>
+								<Code class="h-4 w-4 text-green-400" />
+								Implement
+							</button>
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('review')}
+							>
+								<Eye class="h-4 w-4 text-yellow-400" />
+								Review
+							</button>
+						</div>
+					</div>
+				</div>
 			{:else}
 				<div class="flex-1 flex items-center justify-center">
-					<p class="text-sm text-muted-foreground">Send a message to start a new session.</p>
+					<div class="flex flex-col items-center gap-4">
+						<p class="text-sm text-muted-foreground">Start a phase or send a message</p>
+						<div class="flex gap-2">
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('spec')}
+							>
+								<FileText class="h-4 w-4 text-blue-400" />
+								Spec
+							</button>
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('implement')}
+							>
+								<Code class="h-4 w-4 text-green-400" />
+								Implement
+							</button>
+							<button
+								class="flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-muted/50 hover:bg-muted text-sm text-foreground transition-colors"
+								onclick={() => handleStartPhase('review')}
+							>
+								<Eye class="h-4 w-4 text-yellow-400" />
+								Review
+							</button>
+						</div>
+					</div>
 				</div>
 			{/if}
 

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -176,6 +176,14 @@ export async function startSession(repoId: number, issueNumber: number): Promise
 	return invoke('session_start', { repoId, issueNumber });
 }
 
+export async function startImplementSession(repoId: number, issueNumber: number): Promise<void> {
+	return invoke('session_start_implement', { repoId, issueNumber });
+}
+
+export async function startReviewSession(repoId: number, issueNumber: number): Promise<void> {
+	return invoke('session_start_review', { repoId, issueNumber });
+}
+
 export async function respondToSession(sessionId: string, message: string): Promise<void> {
 	return invoke('session_respond', { sessionId, message });
 }


### PR DESCRIPTION
## Summary
- New chat tabs now open empty instead of immediately sending the system prompt for the spec phase
- Users explicitly choose Spec, Implement, or Review via phase buttons before anything is sent
- Added frontend wrappers for `session_start_implement` and `session_start_review` Tauri commands
- Pending "new" tab appears in the tab bar with close support and proper state management

## Test plan
- [ ] Click "+" to create a new tab — verify no backend session is started
- [ ] Click each phase button (Spec, Implement, Review) — verify the correct session type launches
- [ ] Close the pending tab via the X — verify it returns to the previous session
- [ ] Switch between existing session tabs and the pending tab — verify correct highlight state