### PR TITLE
feat: add opencode as a provider

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use tauri::Manager;
 mod claude_provider;
 mod codex_provider;
 mod db;
+mod opencode_provider;
 mod github;
 mod polling;
 mod provider;

--- a/src-tauri/src/opencode_provider.rs
+++ b/src-tauri/src/opencode_provider.rs
@@ -1,0 +1,254 @@
+use crate::provider::{ParsedLine, Provider, ProviderKind, SessionConfig};
+use crate::sdk_types::LogEntry;
+use serde_json::Value;
+
+/// Opencode CLI provider.
+pub struct OpencodeProvider;
+
+impl Provider for OpencodeProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Opencode
+    }
+
+    fn find_binary(&self) -> Result<String, String> {
+        if let Ok(home) = std::env::var("HOME") {
+            let local_path = format!("{home}/.local/bin/opencode");
+            if std::path::Path::new(&local_path).exists() {
+                return Ok(local_path);
+            }
+        }
+
+        for path in &["/usr/local/bin/opencode", "/opt/homebrew/bin/opencode"] {
+            if std::path::Path::new(path).exists() {
+                return Ok(path.to_string());
+            }
+        }
+
+        let output = std::process::Command::new("/usr/bin/which")
+            .arg("opencode")
+            .output()
+            .map_err(|e| format!("Failed to run which: {e}"))?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Err("opencode CLI not found. Install it from https://opencode.ai".to_string())
+        }
+    }
+
+    fn build_command(
+        &self,
+        binary_path: &str,
+        config: &SessionConfig,
+    ) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(binary_path);
+
+        cmd.arg("run");
+        cmd.args(["--format", "json"]);
+        cmd.args(["--model", &config.model]);
+        cmd.args(["--dir", &config.worktree_path]);
+
+        // Map effort to opencode's --variant flag
+        if !config.effort.is_empty() {
+            cmd.args(["--variant", &config.effort]);
+        }
+
+        // Resume a previous session
+        if let Some(ref resume_id) = config.resume_session_id {
+            cmd.args(["--session", resume_id]);
+        }
+
+        // Pass the user prompt as positional message
+        cmd.arg(&config.user_prompt);
+
+        cmd
+    }
+
+    fn parse_line(&self, line: &str) -> ParsedLine {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return ParsedLine {
+                entries: vec![],
+                session_id: None,
+                cost_usd: None,
+            };
+        }
+
+        if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+            return self.parse_json_line(&json);
+        }
+
+        // Plain text fallback
+        ParsedLine {
+            entries: vec![LogEntry {
+                event_type: "message".into(),
+                content: trimmed.to_string(),
+            }],
+            session_id: None,
+            cost_usd: None,
+        }
+    }
+}
+
+impl OpencodeProvider {
+    /// Parse opencode `run --format json` JSONL output.
+    ///
+    /// Event types from `opencode run --format json`:
+    ///   text        — { part: { type: "text", text } }
+    ///   tool_use    — { part: { tool, state: { status, input, output, error } } }
+    ///   step_start  — { part: { type: "step-start" } }
+    ///   step_finish — { part: { type: "step-finish" } }
+    ///   reasoning   — { part: { type: "reasoning", text } }
+    ///   error       — { error: { name, data: { message } } }
+    fn parse_json_line(&self, json: &Value) -> ParsedLine {
+        let event_type = json["type"].as_str().unwrap_or("");
+
+        // Capture sessionID from any event
+        let session_id = json["sessionID"].as_str().map(String::from);
+
+        match event_type {
+            // Assistant text response
+            "text" => {
+                let text = json["part"]["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if text.is_empty() {
+                    return ParsedLine { entries: vec![], session_id, cost_usd: None };
+                }
+                ParsedLine {
+                    entries: vec![LogEntry {
+                        event_type: "message".into(),
+                        content: text,
+                    }],
+                    session_id,
+                    cost_usd: None,
+                }
+            }
+
+            // Tool use completion/error
+            "tool_use" => {
+                let part = &json["part"];
+                let tool_name = part["tool"].as_str().unwrap_or("tool");
+                let status = part["state"]["status"].as_str().unwrap_or("");
+
+                if status == "error" {
+                    let error = part["state"]["error"]
+                        .as_str()
+                        .unwrap_or("Unknown error")
+                        .to_string();
+                    return ParsedLine {
+                        entries: vec![LogEntry {
+                            event_type: "error".into(),
+                            content: format!("{tool_name} failed: {error}"),
+                        }],
+                        session_id,
+                        cost_usd: None,
+                    };
+                }
+
+                let content = match tool_name {
+                    "bash" => {
+                        let cmd = part["state"]["input"]["command"]
+                            .as_str()
+                            .unwrap_or("command");
+                        let cmd_display: String = cmd.chars().take(120).collect();
+                        format!("Bash: {cmd_display}")
+                    }
+                    "edit" => {
+                        let file = part["state"]["input"]["filePath"]
+                            .as_str()
+                            .unwrap_or("file");
+                        format!("Edit: {file}")
+                    }
+                    "write" => {
+                        let file = part["state"]["input"]["filePath"]
+                            .as_str()
+                            .unwrap_or("file");
+                        format!("Write: {file}")
+                    }
+                    "read" => {
+                        let file = part["state"]["input"]["filePath"]
+                            .as_str()
+                            .unwrap_or("file");
+                        format!("Read: {file}")
+                    }
+                    "glob" => {
+                        let pattern = part["state"]["input"]["pattern"]
+                            .as_str()
+                            .unwrap_or("*");
+                        format!("Glob: {pattern}")
+                    }
+                    "grep" => {
+                        let pattern = part["state"]["input"]["pattern"]
+                            .as_str()
+                            .unwrap_or("");
+                        format!("Grep: {pattern}")
+                    }
+                    "task" => {
+                        let desc = part["state"]["input"]["description"]
+                            .as_str()
+                            .unwrap_or("task");
+                        format!("Task: {desc}")
+                    }
+                    _ => {
+                        let title = part["state"]["title"]
+                            .as_str()
+                            .unwrap_or(tool_name);
+                        title.to_string()
+                    }
+                };
+
+                ParsedLine {
+                    entries: vec![LogEntry {
+                        event_type: "tool_call".into(),
+                        content,
+                    }],
+                    session_id,
+                    cost_usd: None,
+                }
+            }
+
+            // Thinking/reasoning
+            "reasoning" => {
+                let text = json["part"]["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if text.is_empty() {
+                    return ParsedLine { entries: vec![], session_id, cost_usd: None };
+                }
+                ParsedLine {
+                    entries: vec![LogEntry {
+                        event_type: "thinking".into(),
+                        content: text,
+                    }],
+                    session_id,
+                    cost_usd: None,
+                }
+            }
+
+            // Error
+            "error" => {
+                let content = json["error"]["data"]["message"]
+                    .as_str()
+                    .or_else(|| json["error"]["name"].as_str())
+                    .unwrap_or("Unknown error")
+                    .to_string();
+                ParsedLine {
+                    entries: vec![LogEntry {
+                        event_type: "error".into(),
+                        content,
+                    }],
+                    session_id,
+                    cost_usd: None,
+                }
+            }
+
+            // step_start, step_finish — no useful display info
+            _ => ParsedLine { entries: vec![], session_id, cost_usd: None },
+        }
+    }
+}

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -13,6 +13,7 @@ use crate::types::*;
 pub enum ProviderKind {
     Claude,
     Codex,
+    Opencode,
 }
 
 impl ProviderKind {
@@ -20,6 +21,7 @@ impl ProviderKind {
         match self {
             Self::Claude => "claude",
             Self::Codex => "codex",
+            Self::Opencode => "opencode",
         }
     }
 
@@ -27,6 +29,7 @@ impl ProviderKind {
         match s {
             "claude" => Ok(Self::Claude),
             "codex" => Ok(Self::Codex),
+            "opencode" => Ok(Self::Opencode),
             other => Err(format!("Unknown provider: {other}")),
         }
     }
@@ -35,6 +38,7 @@ impl ProviderKind {
         match self {
             Self::Claude => "Claude Code",
             Self::Codex => "Codex",
+            Self::Opencode => "Opencode",
         }
     }
 }
@@ -108,6 +112,49 @@ pub fn all_models() -> Vec<ModelInfo> {
             id: "gpt-5.2-codex",
             display_name: "GPT-5.2-Codex",
             provider: ProviderKind::Codex,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        // Opencode models
+        ModelInfo {
+            id: "openai/gpt-5.4",
+            display_name: "GPT-5.4 (Opencode)",
+            provider: ProviderKind::Opencode,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        ModelInfo {
+            id: "openai/gpt-5.3-codex",
+            display_name: "GPT-5.3-Codex (Opencode)",
+            provider: ProviderKind::Opencode,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        ModelInfo {
+            id: "github-copilot/claude-sonnet-4.6",
+            display_name: "Sonnet 4.6 (Copilot)",
+            provider: ProviderKind::Opencode,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        ModelInfo {
+            id: "github-copilot/claude-opus-4.6",
+            display_name: "Opus 4.6 (Copilot)",
+            provider: ProviderKind::Opencode,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        ModelInfo {
+            id: "github-copilot/gpt-5.4",
+            display_name: "GPT-5.4 (Copilot)",
+            provider: ProviderKind::Opencode,
+            default_effort: "medium",
+            effort_levels: &["low", "medium", "high"],
+        },
+        ModelInfo {
+            id: "github-copilot/gemini-2.5-pro",
+            display_name: "Gemini 2.5 Pro (Copilot)",
+            provider: ProviderKind::Opencode,
             default_effort: "medium",
             effort_levels: &["low", "medium", "high"],
         },
@@ -311,6 +358,7 @@ pub fn get_provider(model_id: &str) -> Result<Box<dyn Provider>, String> {
     match kind {
         ProviderKind::Claude => Ok(Box::new(crate::claude_provider::ClaudeProvider)),
         ProviderKind::Codex => Ok(Box::new(crate::codex_provider::CodexProvider)),
+        ProviderKind::Opencode => Ok(Box::new(crate::opencode_provider::OpencodeProvider)),
     }
 }
 
@@ -319,6 +367,7 @@ pub fn get_provider_by_kind(kind: ProviderKind) -> Box<dyn Provider> {
     match kind {
         ProviderKind::Claude => Box::new(crate::claude_provider::ClaudeProvider),
         ProviderKind::Codex => Box::new(crate::codex_provider::CodexProvider),
+        ProviderKind::Opencode => Box::new(crate::opencode_provider::OpencodeProvider),
     }
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -4,7 +4,7 @@ export type SessionStage = 'spec' | 'implement' | 'review' | 'ci_fix' | 'merge_c
 
 export type SessionStatus = 'initializing' | 'setup' | 'running' | 'completed' | 'failed';
 
-export type ProviderKind = 'claude' | 'codex';
+export type ProviderKind = 'claude' | 'codex' | 'opencode';
 
 export interface GitHubUser {
 	login: string;
@@ -127,11 +127,19 @@ export const MODEL_REGISTRY: ModelInfo[] = [
 	{ id: 'gpt-5.3-codex-spark', display_name: 'GPT-5.3-Codex-Spark', provider: 'codex', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
 	{ id: 'gpt-5.3-codex', display_name: 'GPT-5.3-Codex', provider: 'codex', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
 	{ id: 'gpt-5.2-codex', display_name: 'GPT-5.2-Codex', provider: 'codex', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	// Opencode models
+	{ id: 'openai/gpt-5.4', display_name: 'GPT-5.4 (Opencode)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	{ id: 'openai/gpt-5.3-codex', display_name: 'GPT-5.3-Codex (Opencode)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	{ id: 'github-copilot/claude-sonnet-4.6', display_name: 'Sonnet 4.6 (Copilot)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	{ id: 'github-copilot/claude-opus-4.6', display_name: 'Opus 4.6 (Copilot)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	{ id: 'github-copilot/gpt-5.4', display_name: 'GPT-5.4 (Copilot)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
+	{ id: 'github-copilot/gemini-2.5-pro', display_name: 'Gemini 2.5 Pro (Copilot)', provider: 'opencode', default_effort: 'medium', effort_levels: ['low', 'medium', 'high'] },
 ];
 
 export const PROVIDER_LABELS: Record<ProviderKind, string> = {
 	claude: 'Claude Code',
 	codex: 'Codex',
+	opencode: 'Opencode',
 };
 
 export function getModelInfo(modelId: string): ModelInfo | undefined {


### PR DESCRIPTION
Adds opencode as a third AI provider alongside Claude and Codex. The opencode CLI enables access to models from multiple backends (OpenAI, GitHub Copilot) through a single tool.

- New `OpencodeProvider` implementing the `Provider` trait with `opencode run --format json` JSONL parsing
- `ProviderKind::Opencode` variant added to enum, model registry, and provider factory
- 6 initial models: OpenAI GPT-5.4/5.3-Codex, Copilot Sonnet 4.6/Opus 4.6/GPT-5.4/Gemini 2.5 Pro
- Frontend `ProviderKind` type and `MODEL_REGISTRY` updated to match