### PR TITLE
fix: remove unused variable, field, and function in providers

### DIFF
--- a/src-tauri/src/codex_provider.rs
+++ b/src-tauri/src/codex_provider.rs
@@ -162,7 +162,7 @@ impl CodexProvider {
                     "command_execution" => {
                         let command = item["command"].as_str().unwrap_or("command");
                         let exit_code = item["exit_code"].as_i64();
-                        let status = item["status"].as_str().unwrap_or("");
+                        let _status = item["status"].as_str().unwrap_or("");
 
                         // Truncate command for display
                         let cmd_display: String = command.chars().take(120).collect();

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -184,7 +184,6 @@ pub struct SessionConfig {
 
 /// The result of running a provider session.
 pub struct ProviderSessionResult {
-    pub cli_session_id: Option<String>,
     pub cost_usd: Option<f64>,
 }
 
@@ -314,7 +313,6 @@ pub async fn run_provider_session(
         use std::os::unix::process::ExitStatusExt;
         if status.signal() == Some(libc::SIGTERM) {
             return Ok(ProviderSessionResult {
-                cli_session_id,
                 cost_usd,
             });
         }
@@ -342,25 +340,11 @@ pub async fn run_provider_session(
     }
 
     Ok(ProviderSessionResult {
-        cli_session_id,
         cost_usd,
     })
 }
 
 // ── Provider Registry ───────────────────────────────────────────────────
-
-/// Get the appropriate provider for a model ID.
-pub fn get_provider(model_id: &str) -> Result<Box<dyn Provider>, String> {
-    let kind = provider_for_model(model_id).ok_or_else(|| {
-        format!("Unknown model: {model_id}")
-    })?;
-
-    match kind {
-        ProviderKind::Claude => Ok(Box::new(crate::claude_provider::ClaudeProvider)),
-        ProviderKind::Codex => Ok(Box::new(crate::codex_provider::CodexProvider)),
-        ProviderKind::Opencode => Ok(Box::new(crate::opencode_provider::OpencodeProvider)),
-    }
-}
 
 /// Get a provider by kind (for when you know the provider but not the model).
 pub fn get_provider_by_kind(kind: ProviderKind) -> Box<dyn Provider> {


### PR DESCRIPTION
## Summary

Fixes 3 Rust compiler warnings in the provider modules:

- Prefix unused `status` variable with `_` in `codex_provider.rs`
- Remove unused `cli_session_id` field from `ProviderSessionResult` (already saved to DB inside `run_provider_session`)
- Remove unused `get_provider` function (only `get_provider_by_kind` is called)

Compiles clean with zero warnings.