### PR TITLE
Use cargo build in setup for faster dev startup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,5 +7,5 @@ bun install
 # Generate SvelteKit types
 bunx svelte-kit sync
 
-# Build Rust deps + generate Tauri schemas (non-interactive)
-cargo check --manifest-path src-tauri/Cargo.toml
+# Full Rust build so dev.sh starts fast (binary is already compiled)
+cargo build --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## Summary

- Changes `setup.sh` to run `cargo build` instead of `cargo check`, so the full Rust binary is compiled during setup rather than on the first `dev.sh` run.
- This eliminates the long initial compilation wait when running `dev.sh` after setup.