### PR TITLE
feat: replace macOS title bar with overlay stoplight toolbar

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,9 @@
         "minHeight": 600,
         "resizable": true,
         "fullscreen": false,
-        "decorations": true
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": { "x": 12, "y": 28 }
       }
     ],
     "security": {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -181,7 +181,7 @@
 	{:else}
 		<!-- Main App -->
 		<!-- Top Bar -->
-		<header class="shrink-0 flex items-center justify-between px-4 py-2 border-b border-border bg-background/80 backdrop-blur-sm" data-tauri-drag-region>
+		<header class="shrink-0 flex items-center justify-between pr-4 pl-[95px] h-[52px] border-b border-border bg-background/80 backdrop-blur-sm" data-tauri-drag-region>
 			<div class="flex items-center gap-3">
 				<span class="text-sm font-semibold text-foreground">AutoDev</span>
 				<RepoSelector />


### PR DESCRIPTION
Removes the default macOS title bar and uses Tauri's overlay title bar style instead. The app's custom header now serves as the sole top bar, with content vertically aligned alongside the traffic light buttons. Left padding added to prevent overlap with the stoplights.