### PR TITLE
feat: local SQLite-based kanban column state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ There are no tests yet.
 ### Rust Backend (`src-tauri/src/`)
 
 - `lib.rs` — App entry point. Registers `AppState` (SQLite connection + HTTP client), starts polling, registers all Tauri commands.
-- `db.rs` — All SQLite operations. Database lives at `~/.autodev/autodev.db`. Tables: `repos`, `sessions`, `auth`, `settings`, `agent_prompts`, `session_logs`.
-- `github.rs` — GitHub REST API calls (auth via `gh` CLI token, issues, labels, PRs, merge). Also has `ensure_labels()` which creates `autodev:*` labels on repo add.
+- `db.rs` — All SQLite operations. Database lives at `~/.autodev/autodev.db`. Tables: `repos`, `sessions`, `auth`, `settings`, `agent_prompts`, `session_logs`, `issue_state`.
+- `issue_state.rs` — Tauri commands for reading/writing per-issue column state (`get_issue_states`, `set_issue_column`).
+- `github.rs` — GitHub REST API calls (auth via `gh` CLI token, issues, PRs, merge).
 - `sessions.rs` — Core session lifecycle. Spawns `claude` CLI as a subprocess with `--output-format stream-json`, streams stdout into session logs and Tauri events. Three entry points: `session_start` (spec), `session_start_implement`, `session_start_review`. Permission modes: `plan` for spec, `bypassPermissions` for implement/review.
 - `worktrees.rs` — Git worktree creation/removal, setup script execution, diff generation, branch pushing.
 - `polling.rs` — Background task that polls GitHub issues on an interval and emits `issues-updated` events.
@@ -46,7 +47,7 @@ There are no tests yet.
 
 ### Svelte Frontend (`src/`)
 
-- `src/lib/types/index.ts` — TypeScript types mirroring the Rust types. Also defines `COLUMN_CONFIG`, `COLUMN_ORDER`, and the column-resolution functions `getColumnForIssue()` / `getColumnForSession()`.
+- `src/lib/types/index.ts` — TypeScript types mirroring the Rust types. Also defines `COLUMN_CONFIG`, `COLUMN_ORDER`, and `getColumnForSession()`.
 - `src/lib/stores/backend.ts` — Typed wrapper around all `invoke()` calls. Single import point for all backend communication.
 - `src/lib/stores/` — Svelte stores for reactive state: `issues.ts` (with derived `issuesByColumn`), `sessions.ts` (with derived `sessionByIssue`), `repos.ts`, `auth.ts`, `settings.ts`, `ui.ts`.
 - `src/lib/components/` — UI components: `KanbanBoard`, `KanbanColumn`, `IssueCard`, `CardDetail` (modal), `RepoSelector`, `SettingsDialog`, `NewIssueDialog`, `AddRepoDialog`, `RemoveRepoDialog`, `AgentLog`.
@@ -54,10 +55,10 @@ There are no tests yet.
 
 ### Key Data Flow
 
-1. GitHub labels (`autodev:planning`, `autodev:in-progress`, `autodev:blocked`, `autodev:review`) are the source of truth for board position.
-2. Local session state overrides label-based positioning while a session is active (`sessionByIssue` derived store).
+1. Board column position is persisted locally in the `issue_state` SQLite table. Issues default to `backlog` when no state exists.
+2. Local session state overrides persisted column state while a session is active (`sessionByIssue` derived store).
 3. Polling emits `issues-updated` events; session lifecycle emits `session-status` and `session-log` events. Frontend stores react to both.
-4. Issues are never stored locally — they're fetched from GitHub on every poll. Only sessions, auth, settings, and prompts are persisted in SQLite.
+4. Issues themselves are never stored locally — they're fetched from GitHub on every poll. Sessions, auth, settings, prompts, and issue column state are persisted in SQLite.
 
 ## Tech Stack
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -89,6 +89,13 @@ fn create_tables(conn: &Connection) -> Result<(), String> {
             event_type TEXT NOT NULL,
             content TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS issue_state (
+            repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+            issue_number INTEGER NOT NULL,
+            column_id TEXT NOT NULL,
+            PRIMARY KEY (repo_id, issue_number)
+        );
         ",
     )
     .map_err(|e| format!("Failed to create tables: {e}"))
@@ -305,18 +312,13 @@ fn seed_default_prompts(conn: &Connection) -> Result<(), String> {
              1. Check for an existing spec by reading the issue's comments:\n\
              \x20  `gh api repos/{owner}/{repo}/issues/{number}/comments --jq '.[].body'`\n\
              \x20  Look for a comment that starts with \"## Spec\" or contains a specification.\n\
-             2. **If an existing spec is found**: Present it to the user and ask if there's anything they'd like to update. If they confirm it's good, skip to step 6.\n\
+             2. **If an existing spec is found**: Present it to the user and ask if there's anything they'd like to update. If they confirm it's good, you're done — tell the user the spec is ready.\n\
              3. **If no spec exists**: Read the issue thoroughly and explore the codebase to understand the architecture, conventions, and relevant code paths.\n\
              4. If you have blocking questions that prevent you from writing the spec:\n\
              \x20  a. Post a comment on the issue with your questions: `gh issue comment {number} -R {owner}/{repo} --body \"## Questions\\n\\n...\"`\n\
-             \x20  b. Add the blocked label: `gh issue edit {number} -R {owner}/{repo} --add-label \"autodev:blocked\"`\n\
-             \x20  c. Remove the planning label if present: `gh issue edit {number} -R {owner}/{repo} --remove-label \"autodev:planning\"`\n\
-             \x20  d. Stop and tell the user you've posted questions on the issue.\n\
+             \x20  b. Stop and tell the user you've posted questions on the issue.\n\
              5. Write the spec and post it as a comment on the issue:\n\
-             \x20  `gh issue comment {number} -R {owner}/{repo} --body \"## Spec\\n\\n...\"`\n\
-             6. Move the issue to in-progress to trigger implementation:\n\
-             \x20  a. Add the in-progress label: `gh issue edit {number} -R {owner}/{repo} --add-label \"autodev:in-progress\"`\n\
-             \x20  b. Remove planning/blocked labels if present: `gh issue edit {number} -R {owner}/{repo} --remove-label \"autodev:planning\" --remove-label \"autodev:blocked\"`\n\n\
+             \x20  `gh issue comment {number} -R {owner}/{repo} --body \"## Spec\\n\\n...\"`\n\n\
              ## Specification format\n\
              Your spec comment should include:\n\
              - **Summary**: One-sentence description of what this change does.\n\
@@ -327,7 +329,7 @@ fn seed_default_prompts(conn: &Connection) -> Result<(), String> {
              - Do NOT make any code changes. This is a read-only analysis stage.\n\
              - Do NOT guess at implementation details you haven't verified by reading the code.\n\
              - Keep the spec concise and actionable — a developer should be able to implement from it.\n\
-             - Always use the `gh` CLI to interact with GitHub — never modify labels or comments through any other means.",
+             - Do NOT modify GitHub labels — board state is managed by the app automatically.",
         ),
         (
             "implement",
@@ -512,6 +514,10 @@ pub fn delete_repo_cascade(conn: &Connection, repo_id: i64) -> Result<(), String
     conn.execute("DELETE FROM sessions WHERE repo_id = ?1", params![repo_id])
         .map_err(|e| format!("Failed to delete sessions: {e}"))?;
 
+    // Delete issue state
+    conn.execute("DELETE FROM issue_state WHERE repo_id = ?1", params![repo_id])
+        .map_err(|e| format!("Failed to delete issue states: {e}"))?;
+
     // Delete repo-specific settings
     conn.execute(
         "DELETE FROM settings WHERE key = ?1",
@@ -607,6 +613,46 @@ pub fn update_repo(conn: &Connection, repo: &RepoConfig) -> Result<(), String> {
         ],
     )
     .map_err(|e| format!("Failed to update repo: {e}"))?;
+    Ok(())
+}
+
+// ── Issue State ─────────────────────────────────────────────────────────
+
+/// Get all issue column assignments for a repo.
+pub fn get_issue_states_for_repo(
+    conn: &Connection,
+    repo_id: i64,
+) -> Result<Vec<(i64, String)>, String> {
+    let mut stmt = conn
+        .prepare("SELECT issue_number, column_id FROM issue_state WHERE repo_id = ?1")
+        .map_err(|e| format!("Failed to query issue states: {e}"))?;
+
+    let rows = stmt
+        .query_map(params![repo_id], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|e| format!("Failed to query issue states: {e}"))?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        result.push(row.map_err(|e| format!("Failed to read issue state: {e}"))?);
+    }
+    Ok(result)
+}
+
+/// Set the column for an issue. Creates or updates the row.
+pub fn set_issue_column(
+    conn: &Connection,
+    repo_id: i64,
+    issue_number: i64,
+    column_id: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO issue_state (repo_id, issue_number, column_id) VALUES (?1, ?2, ?3)
+         ON CONFLICT(repo_id, issue_number) DO UPDATE SET column_id = excluded.column_id",
+        params![repo_id, issue_number, column_id],
+    )
+    .map_err(|e| format!("Failed to set issue column: {e}"))?;
     Ok(())
 }
 

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -222,9 +222,6 @@ pub async fn github_add_repo(
         db::set_setting(&db, &format!("repo_{repo_id}_path"), repo_dir.to_str().unwrap())?;
     }
 
-    // Ensure autodev labels exist on the repo
-    ensure_labels(client, &token, &owner, &name).await?;
-
     Ok(RepoConfig { id: repo_id, ..repo })
 }
 
@@ -302,9 +299,6 @@ pub async fn github_add_local_repo(
         let db = state.db.lock().map_err(|e| format!("DB lock error: {e}"))?;
         db::set_setting(&db, &format!("repo_{repo_id}_path"), &path)?;
     }
-
-    // Ensure autodev labels exist on the repo
-    ensure_labels(client, &token, &owner, &name).await?;
 
     Ok(RepoConfig { id: repo_id, ..repo })
 }
@@ -527,66 +521,6 @@ pub async fn github_create_issue(
 }
 
 #[tauri::command]
-pub async fn github_add_label(
-    state: tauri::State<'_, AppState>,
-    owner: String,
-    name: String,
-    issue_number: i64,
-    label: String,
-) -> Result<(), String> {
-    let token = get_token(&state)?;
-    let client = &state.http_client;
-
-    let resp = client
-        .post(format!(
-            "{GITHUB_API}/repos/{owner}/{name}/issues/{issue_number}/labels"
-        ))
-        .headers(github_headers(&token))
-        .json(&json!({ "labels": [label] }))
-        .send()
-        .await
-        .map_err(|e| format!("Failed to add label: {e}"))?;
-
-    if !resp.status().is_success() {
-        return Err(format!("GitHub API error adding label: {}", resp.status()));
-    }
-
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn github_remove_label(
-    state: tauri::State<'_, AppState>,
-    owner: String,
-    name: String,
-    issue_number: i64,
-    label: String,
-) -> Result<(), String> {
-    let token = get_token(&state)?;
-    let client = &state.http_client;
-
-    let encoded_label = urlencoding_label(&label);
-    let resp = client
-        .delete(format!(
-            "{GITHUB_API}/repos/{owner}/{name}/issues/{issue_number}/labels/{encoded_label}"
-        ))
-        .headers(github_headers(&token))
-        .send()
-        .await
-        .map_err(|e| format!("Failed to remove label: {e}"))?;
-
-    // Ignore 404 — label might not be present
-    if !resp.status().is_success() && resp.status() != reqwest::StatusCode::NOT_FOUND {
-        return Err(format!(
-            "GitHub API error removing label: {}",
-            resp.status()
-        ));
-    }
-
-    Ok(())
-}
-
-#[tauri::command]
 pub async fn github_post_comment(
     state: tauri::State<'_, AppState>,
     owner: String,
@@ -743,53 +677,6 @@ async fn fetch_current_user(client: &Client, token: &str) -> Result<GitHubUser, 
         .map_err(|e| format!("Failed to parse user: {e}"))?;
 
     Ok(user)
-}
-
-async fn ensure_labels(
-    client: &Client,
-    token: &str,
-    owner: &str,
-    name: &str,
-) -> Result<(), String> {
-    let labels = [
-        ("autodev:planning", "0E8A16"),
-        ("autodev:in-progress", "1D76DB"),
-        ("autodev:blocked", "E4E669"),
-        ("autodev:review", "5319E7"),
-    ];
-
-    for (label_name, color) in &labels {
-        let resp = client
-            .post(format!("{GITHUB_API}/repos/{owner}/{name}/labels"))
-            .headers(github_headers(token))
-            .json(&json!({
-                "name": label_name,
-                "color": color,
-            }))
-            .send()
-            .await;
-
-        match resp {
-            Ok(r) => {
-                // 422 means label already exists — that's fine
-                if !r.status().is_success()
-                    && r.status() != reqwest::StatusCode::UNPROCESSABLE_ENTITY
-                {
-                    eprintln!("Warning: Failed to create label {label_name}: {}", r.status());
-                }
-            }
-            Err(e) => {
-                eprintln!("Warning: Failed to create label {label_name}: {e}");
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Percent-encode a label for use in URL paths (colons are fine per GitHub API)
-fn urlencoding_label(label: &str) -> String {
-    label.replace(' ', "%20")
 }
 
 /// Fetch issues for a repo (non-command helper used by polling)

--- a/src-tauri/src/issue_state.rs
+++ b/src-tauri/src/issue_state.rs
@@ -1,0 +1,22 @@
+use crate::db;
+use crate::AppState;
+
+#[tauri::command]
+pub async fn get_issue_states(
+    state: tauri::State<'_, AppState>,
+    repo_id: i64,
+) -> Result<Vec<(i64, String)>, String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::get_issue_states_for_repo(&db, repo_id)
+}
+
+#[tauri::command]
+pub async fn set_issue_column(
+    state: tauri::State<'_, AppState>,
+    repo_id: i64,
+    issue_number: i64,
+    column_id: String,
+) -> Result<(), String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock: {e}"))?;
+    db::set_issue_column(&db, repo_id, issue_number, &column_id)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod github;
 mod polling;
 mod provider;
 mod sdk_types;
+mod issue_state;
 mod sessions;
 mod sleep;
 mod types;
@@ -87,8 +88,6 @@ pub fn run() {
             // GitHub issues
             github::github_fetch_issues,
             github::github_create_issue,
-            github::github_add_label,
-            github::github_remove_label,
             github::github_post_comment,
             github::github_create_pr,
             github::github_squash_merge,
@@ -118,6 +117,9 @@ pub fn run() {
             sessions::get_repo_path,
             sessions::get_selected_repo_id,
             sessions::set_selected_repo_id,
+            // Issue State
+            issue_state::get_issue_states,
+            issue_state::set_issue_column,
             // Polling
             polling::force_poll,
         ])

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -224,7 +224,7 @@ pub async fn session_start(
             "GitHub Issue #{issue_number} in {owner}/{name}\n\n\
              Follow the spec process: check for an existing spec in the issue comments, \
              explore the codebase, and produce or update the spec. \
-             Use `gh` CLI for all GitHub interactions (comments, labels). \
+             Use `gh` CLI for all GitHub interactions (comments). \
              The repo is {owner}/{name} and the issue number is {issue_number}."
         )
     };
@@ -238,6 +238,8 @@ pub async fn session_start(
     let model_for_spawn = effective_model;
     let effort_for_spawn = effective_effort;
     let provider_kind = effective_provider;
+    let spec_repo_id = repo_id;
+    let spec_issue_number = issue_number;
 
     tokio::spawn(async move {
         let prov = provider::get_provider_by_kind(provider_kind);
@@ -259,6 +261,17 @@ pub async fn session_start(
                     save_session_cost(&app, session_db_id, cost);
                 }
                 update_status_via_app(&app, session_db_id, "completed", None);
+
+                // Check if the spec session was blocked (posted questions but no spec)
+                if let Ok(db) = app.state::<crate::AppState>().db.lock() {
+                    if let Ok(logs) = db::get_session_logs(&db, session_db_id) {
+                        let has_questions = logs.iter().any(|l| l.content.contains("## Questions"));
+                        let has_spec = logs.iter().any(|l| l.content.contains("## Spec"));
+                        if has_questions && !has_spec {
+                            let _ = db::set_issue_column(&db, spec_repo_id, spec_issue_number, "blocked");
+                        }
+                    }
+                }
 
                 let _ = app.emit(
                     "session-log",

--- a/src/lib/components/IssueCard.svelte
+++ b/src/lib/components/IssueCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import type { Issue } from '$lib/types';
-	import { getColumnForIssue } from '$lib/types';
+	import { getColumnForSession } from '$lib/types';
 	import { sessionByIssue } from '$lib/stores/sessions';
+	import { issueStates } from '$lib/stores/issues';
 	import { repos } from '$lib/stores/repos';
 	import { selectedIssue } from '$lib/stores/ui';
 	import * as backend from '$lib/stores/backend';
@@ -9,12 +10,16 @@
 
 	let { issue }: { issue: Issue } = $props();
 
-	let column = $derived(getColumnForIssue(issue));
-
 	let repoConfig = $derived($repos.find((r) => r.owner === issue.repo_owner && r.name === issue.repo_name));
 	let sessionKey = $derived(repoConfig ? `${repoConfig.id}:${issue.number}` : null);
 	let session = $derived(sessionKey ? $sessionByIssue.get(sessionKey) ?? null : null);
 	let hasError = $derived(session?.status === 'failed');
+
+	let column = $derived.by(() => {
+		if (issue.state === 'closed') return 'done';
+		if (session) return getColumnForSession(session);
+		return sessionKey ? ($issueStates.get(sessionKey) ?? 'backlog') : 'backlog';
+	});
 
 	function timeAgo(dateStr: string): string {
 		const now = Date.now();

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { Issue, ColumnId } from '$lib/types';
-	import { COLUMN_ORDER, COLUMN_CONFIG, getColumnForIssue } from '$lib/types';
-	import { issuesByColumn, refreshIssues } from '$lib/stores/issues';
+	import type { Issue, ColumnId, RepoConfig } from '$lib/types';
+	import { COLUMN_ORDER, COLUMN_CONFIG } from '$lib/types';
+	import { issuesByColumn, issueStates, refreshIssues } from '$lib/stores/issues';
 	import { repos } from '$lib/stores/repos';
 	import * as backend from '$lib/stores/backend';
 	import { type DndEvent, TRIGGERS } from 'svelte-dnd-action';
@@ -50,7 +50,6 @@
 	}
 
 	async function moveIssueToColumn(targetColumn: ColumnId, issue: Issue) {
-		const currentColumn = getColumnForIssue(issue);
 		const repo = $repos.find(
 			(r) => r.owner === issue.repo_owner && r.name === issue.repo_name
 		);
@@ -62,7 +61,7 @@
 				errorMessage = String(e);
 				setTimeout(() => { errorMessage = ''; }, 8000);
 			}
-			syncLabel(issue, currentColumn, targetColumn);
+			saveColumnState(repo, issue, targetColumn);
 			return;
 		}
 
@@ -83,31 +82,21 @@
 					console.error('Failed to close issue:', e);
 				}
 			}
-			syncLabel(issue, currentColumn, targetColumn);
+			saveColumnState(repo, issue, targetColumn);
 			await refreshIssues(issue.repo_owner, issue.repo_name);
 			return;
 		}
 
-		// For other column moves (no session involved), update labels and refresh
-		syncLabel(issue, currentColumn, targetColumn);
-		await refreshIssues(issue.repo_owner, issue.repo_name);
+		saveColumnState(repo, issue, targetColumn);
 	}
 
-	/** Best-effort label sync to GitHub — fire and forget. */
-	function syncLabel(issue: Issue, fromColumn: ColumnId, toColumn: ColumnId) {
-		const oldLabel = COLUMN_CONFIG[fromColumn].github_label;
-		const newLabel = COLUMN_CONFIG[toColumn].github_label;
-
-		if (oldLabel) {
-			backend
-				.removeLabel(issue.repo_owner, issue.repo_name, issue.number, oldLabel)
-				.catch(() => {});
-		}
-		if (newLabel) {
-			backend
-				.addLabel(issue.repo_owner, issue.repo_name, issue.number, newLabel)
-				.catch(() => {});
-		}
+	function saveColumnState(repo: RepoConfig | undefined, issue: Issue, columnId: ColumnId) {
+		if (!repo) return;
+		issueStates.update((current) => {
+			current.set(`${repo.id}:${issue.number}`, columnId);
+			return new Map(current);
+		});
+		backend.setIssueColumn(repo.id, issue.number, columnId).catch(() => {});
 	}
 </script>
 

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -11,9 +11,10 @@ import type {
 	AppSettings,
 	AgentPrompt,
 	SessionStage,
-	ModelInfo
+	ModelInfo,
+	ColumnId
 } from '$lib/types';
-import { issues } from './issues';
+import { issues, issueStates } from './issues';
 import { sessions, sessionLogs } from './sessions';
 
 // Initialize: set up event listeners for Rust -> frontend events
@@ -113,6 +114,20 @@ export async function initBackend() {
 			return new Map(current);
 		});
 	});
+}
+
+export async function loadIssueStates(repoId: number) {
+	try {
+		const states = await getIssueStates(repoId);
+		issueStates.update((current) => {
+			for (const [issueNumber, columnId] of states) {
+				current.set(`${repoId}:${issueNumber}`, columnId as ColumnId);
+			}
+			return new Map(current);
+		});
+	} catch (_) {
+		// Failed to load issue states
+	}
 }
 
 // Auth
@@ -219,23 +234,17 @@ export async function stopSession(sessionId: string): Promise<void> {
 	return invoke('session_stop', { sessionId });
 }
 
-// Labels
-export async function addLabel(
-	owner: string,
-	name: string,
-	issueNumber: number,
-	label: string
-): Promise<void> {
-	return invoke('github_add_label', { owner, name, issueNumber, label });
+// Issue State
+export async function getIssueStates(repoId: number): Promise<[number, string][]> {
+	return invoke('get_issue_states', { repoId });
 }
 
-export async function removeLabel(
-	owner: string,
-	name: string,
+export async function setIssueColumn(
+	repoId: number,
 	issueNumber: number,
-	label: string
+	columnId: string
 ): Promise<void> {
-	return invoke('github_remove_label', { owner, name, issueNumber, label });
+	return invoke('set_issue_column', { repoId, issueNumber, columnId });
 }
 
 export async function closeIssue(

--- a/src/lib/stores/issues.ts
+++ b/src/lib/stores/issues.ts
@@ -1,14 +1,17 @@
 import { writable, derived } from 'svelte/store';
 import type { Issue, ColumnId } from '$lib/types';
-import { getColumnForIssue, getColumnForSession, COLUMN_ORDER } from '$lib/types';
+import { getColumnForSession, COLUMN_ORDER } from '$lib/types';
 import { selectedRepoId, repos } from './repos';
 import { sessionByIssue } from './sessions';
 
 export const issues = writable<Issue[]>([]);
 
+/** Local column assignments keyed by "repoId:issueNumber" */
+export const issueStates = writable<Map<string, ColumnId>>(new Map());
+
 export const issuesByColumn = derived(
-	[issues, selectedRepoId, repos, sessionByIssue],
-	([$issues, $selectedRepoId, $repos, $sessionByIssue]) => {
+	[issues, selectedRepoId, repos, sessionByIssue, issueStates],
+	([$issues, $selectedRepoId, $repos, $sessionByIssue, $issueStates]) => {
 		const grouped: Record<ColumnId, Issue[]> = {
 			backlog: [],
 			planning: [],
@@ -42,8 +45,8 @@ export const issuesByColumn = derived(
 				const col = getColumnForSession(session);
 				grouped[col].push(issue);
 			} else {
-				// No session — fall back to GitHub labels
-				const col = getColumnForIssue(issue);
+				// Fall back to local DB state, default to backlog
+				const col = $issueStates.get(sessionKey) ?? 'backlog';
 				grouped[col].push(issue);
 			}
 		}

--- a/src/lib/stores/repos.ts
+++ b/src/lib/stores/repos.ts
@@ -8,6 +8,7 @@ export const selectedRepoId = writable<number | null>(null);
 export async function selectRepo(id: number) {
 	selectedRepoId.set(id);
 	await backend.setSelectedRepoId(id);
+	backend.loadIssueStates(id);
 }
 
 export async function removeRepo(id: number) {
@@ -26,7 +27,9 @@ export async function loadRepos(): Promise<RepoConfig[]> {
 	if (list.length > 0) {
 		const savedId = await backend.getSelectedRepoId();
 		const valid = savedId != null && list.some((r) => r.id === savedId);
-		selectedRepoId.set(valid ? savedId : list[0].id);
+		const repoId = valid ? savedId! : list[0].id;
+		selectedRepoId.set(repoId);
+		backend.loadIssueStates(repoId);
 	}
 	return list;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,11 +12,6 @@ export interface GitHubUser {
 	id: number;
 }
 
-export interface GitHubLabel {
-	name: string;
-	color: string;
-}
-
 export interface Issue {
 	id: number;
 	number: number;
@@ -24,7 +19,7 @@ export interface Issue {
 	body: string;
 	state: 'open' | 'closed';
 	assignee: GitHubUser | null;
-	labels: GitHubLabel[];
+	labels: { name: string; color: string }[];
 	created_at: string;
 	updated_at: string;
 	pull_request?: { url: string; html_url: string };
@@ -161,13 +156,13 @@ export interface AppSettings {
 	bypass_permissions: boolean;
 }
 
-export const COLUMN_CONFIG: Record<ColumnId, { label: string; github_label: string | null }> = {
-	backlog: { label: 'Backlog', github_label: null },
-	planning: { label: 'Planning', github_label: 'autodev:planning' },
-	in_progress: { label: 'In Progress', github_label: 'autodev:in-progress' },
-	blocked: { label: 'Blocked', github_label: 'autodev:blocked' },
-	review: { label: 'Ready for Review', github_label: 'autodev:review' },
-	done: { label: 'Done', github_label: null }
+export const COLUMN_CONFIG: Record<ColumnId, { label: string }> = {
+	backlog: { label: 'Backlog' },
+	planning: { label: 'Planning' },
+	in_progress: { label: 'In Progress' },
+	blocked: { label: 'Blocked' },
+	review: { label: 'Ready for Review' },
+	done: { label: 'Done' }
 };
 
 export const COLUMN_ORDER: ColumnId[] = [
@@ -178,17 +173,6 @@ export const COLUMN_ORDER: ColumnId[] = [
 	'review',
 	'done'
 ];
-
-/** Column from GitHub labels only — used when there's no local session. */
-export function getColumnForIssue(issue: Issue): ColumnId {
-	if (issue.state === 'closed') return 'done';
-	const labelNames = issue.labels.map((l) => l.name);
-	if (labelNames.includes('autodev:review')) return 'review';
-	if (labelNames.includes('autodev:blocked')) return 'blocked';
-	if (labelNames.includes('autodev:in-progress')) return 'in_progress';
-	if (labelNames.includes('autodev:planning')) return 'planning';
-	return 'backlog';
-}
 
 /** Column from local session state — takes priority over GitHub labels. */
 export function getColumnForSession(session: Session): ColumnId {


### PR DESCRIPTION
## Summary
- Replaces GitHub label-based board positioning (`autodev:*` labels) with a local `issue_state` SQLite table, keyed by `(repo_id, issue_number)`.
- Removes label CRUD commands (`github_add_label`, `github_remove_label`), the `ensure_labels` flow on repo add, and the `getColumnForIssue` helper that read labels.
- Adds `issue_state.rs` Tauri commands (`get_issue_states`, `set_issue_column`) and loads persisted state on repo select.
- Frontend `IssueCard` and `KanbanBoard` now resolve columns from local state + active session, with `backlog` as the default.
- Spec session auto-detects blocked state (questions posted, no spec) and persists it to the DB.

## Test plan
- [ ] Drag issues between columns and verify positions persist across app restarts
- [ ] Add a new repo and confirm issues appear in backlog (no label sync)
- [ ] Run a spec session that posts questions — verify issue moves to blocked
- [ ] Close an issue from GitHub and confirm it appears in Done column
- [ ] Remove a repo and verify its issue states are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)