### PR TITLE
fix: correct invoke command name for runTest

### DIFF
--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -265,7 +265,7 @@ export async function mergePR(
 }
 
 export async function runTest(sessionId: string): Promise<void> {
-	return invoke('issue_run_test', { sessionId });
+	return invoke('session_run_test', { sessionId });
 }
 
 // Settings


### PR DESCRIPTION
The frontend was calling `invoke('issue_run_test', ...)` but the Rust backend registers the command as `session_run_test`. This mismatch would cause the test command to fail at runtime. Updated the frontend invoke call to use the correct command name.