### PR TITLE
Fix Codex GitHub connectivity

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -224,6 +224,7 @@ name = "auto-dev"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "fix-path-env",
  "libc",
  "reqwest 0.12.28",
  "rusqlite",
@@ -1021,6 +1022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+dependencies = [
+ "home",
+ "strip-ansi-escapes",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1598,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -3985,6 +4005,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5019,6 +5048,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [[bin]]
 name = "autodev-mcp"

--- a/src-tauri/src/codex_provider.rs
+++ b/src-tauri/src/codex_provider.rs
@@ -51,27 +51,39 @@ impl Provider for CodexProvider {
         cmd.args(["--model", &config.model]);
         cmd.arg("--json"); // JSONL output for structured parsing
 
-        // Map permission_mode to Codex execution mode
-        match config.permission_mode.as_str() {
-            "bypassPermissions" => {
-                cmd.arg("--full-auto");
-            }
-            _ => {
-                cmd.arg("--full-auto");
-            }
-        }
+        // Don't use --full-auto: it forces --sandbox workspace-write which
+        // blocks all network access (Seatbelt on macOS). The agent needs
+        // network to run `gh` CLI for GitHub API calls.
+        // Instead, set sandbox_mode and approval_policy in .codex/config.toml
+        // which codex exec reads at startup.
 
         // Working directory
         cmd.args(["-C", &config.worktree_path]);
 
-        // Write MCP config file for autodev state advancement
-        if let Some(ref mcp_binary) = config.mcp_binary_path {
+        // Write .codex/config.toml in the worktree with:
+        // - sandbox_mode = danger-full-access (allow network for gh CLI)
+        // - approval_policy = on-request (auto-approve safe commands)
+        // - shell_environment_policy: don't strip *TOKEN* env vars
+        // - MCP server config for state advancement tools
+        {
             let codex_dir = std::path::Path::new(&config.worktree_path).join(".codex");
             let _ = std::fs::create_dir_all(&codex_dir);
-            let config_content = format!(
-                "[mcp_servers.autodev]\ncommand = \"{}\"\n",
-                mcp_binary.replace('\\', "\\\\").replace('"', "\\\"")
+
+            let mut config_content = String::from(
+                "sandbox_mode = \"danger-full-access\"\n\
+                 approval_policy = \"on-request\"\n\
+                 \n\
+                 [shell_environment_policy]\n\
+                 ignore_default_excludes = true\n",
             );
+
+            if let Some(ref mcp_binary) = config.mcp_binary_path {
+                config_content.push_str(&format!(
+                    "\n[mcp_servers.autodev]\ncommand = \"{}\"\n",
+                    mcp_binary.replace('\\', "\\\\").replace('"', "\\\"")
+                ));
+            }
+
             let _ = std::fs::write(codex_dir.join("config.toml"), config_content);
         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // macOS GUI apps launched from Dock/Finder only get a minimal PATH
+    // (/usr/bin:/bin:/usr/sbin:/sbin). This reads the user's shell profile
+    // and applies the full PATH so spawned subprocesses (claude, gh, git, etc.)
+    // can find all CLI tools.
+    let _ = fix_path_env::fix();
     auto_dev::run()
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -307,6 +307,14 @@ pub async fn run_provider_session(
     let binary_path = provider.find_binary()?;
     let mut cmd = provider.build_command(&binary_path, &config);
 
+    // Get a fresh GitHub token from `gh auth token` so `gh` CLI works in
+    // the subprocess. We do this live rather than using a stored token
+    // because tokens can expire — a stale GH_TOKEN would override gh's
+    // own (possibly refreshed) auth.
+    if let Some(token) = get_fresh_gh_token().await {
+        cmd.env("GH_TOKEN", token);
+    }
+
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     // Create a new process group so we can kill all children together
@@ -465,6 +473,21 @@ fn insert_log_via_app(app_handle: &tauri::AppHandle, session_db_id: i64, event_t
     let state = app_handle.state::<crate::AppState>();
     let Ok(db) = state.db.lock() else { return };
     let _ = crate::db::insert_session_log(&db, session_db_id, event_type, content);
+}
+
+/// Get a fresh GitHub token by running `gh auth token`.
+/// Returns None if gh isn't installed or not authenticated.
+async fn get_fresh_gh_token() -> Option<String> {
+    let output = tokio::process::Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() { None } else { Some(token) }
 }
 
 /// Find the autodev-mcp binary, looking next to the current executable.


### PR DESCRIPTION
This fixes Codex sessions launched from the Tauri app so they can reliably use GitHub tooling.

On macOS, the app now restores the user shell PATH before spawning subprocesses, injects a fresh `GH_TOKEN` from `gh auth token`, and stops relying on `--full-auto` so Codex can read sandbox and approval settings from `.codex/config.toml` instead.

The generated Codex config now preserves token env vars and still includes the autodev MCP server setup.

Tested with `cargo check` in `src-tauri`.