### PR TITLE
Remove reason param from advance_to_blocked

### DIFF
--- a/src-tauri/prompts/implement.md
+++ b/src-tauri/prompts/implement.md
@@ -7,7 +7,7 @@ You are an AI developer implementing a feature or fix.
 4. Write tests for your changes if the project has a testing convention. Match the existing test style.
 5. Run any existing tests or build commands to verify you haven't broken anything.
 6. Commit your changes with a clear, concise commit message.
-7. Call `advance_to_review()` when done, or `advance_to_blocked(reason)` if you need help.
+7. Call `advance_to_review()` when done, or `advance_to_blocked()` if you need help.
 
 ## Rules
 - Do the minimum necessary to solve the issue. Do not refactor unrelated code, add unnecessary abstractions, or over-engineer.
@@ -18,7 +18,7 @@ You are an AI developer implementing a feature or fix.
 ## State Advancement (REQUIRED)
 You have MCP tools to signal state transitions to AutoDev. You MUST call exactly one before finishing:
 
-- `advance_to_blocked(reason)`: Call this if you encounter a problem that requires human input to resolve. Provide specifics about what you need.
+- `advance_to_blocked()`: Call this if you encounter a problem that requires human input to resolve.
 - `advance_to_review(reason)`: Call this AFTER you have committed all changes and the implementation is complete. This signals that the code is ready for human review.
 
 IMPORTANT: Always call one of these tools as your final action. If you need help → call `advance_to_blocked`. If implementation is done → call `advance_to_review`.

--- a/src-tauri/prompts/review.md
+++ b/src-tauri/prompts/review.md
@@ -62,4 +62,4 @@ You are running inside a git worktree for this issue. The diff against the base 
 
 ## State Advancement
 You have an MCP tool available:
-- `advance_to_blocked(reason)`: Call this if the review reveals issues that need a human decision you cannot make on your own.
+- `advance_to_blocked()`: Call this if the review reveals issues that need a human decision you cannot make on your own.

--- a/src-tauri/prompts/spec.md
+++ b/src-tauri/prompts/spec.md
@@ -9,7 +9,7 @@ You have access to the `gh` CLI for interacting with GitHub.
 3. **ELSE IF no spec exists**: Read the issue thoroughly and explore the codebase to understand the architecture, conventions, and relevant code paths.
 4. If you have blocking questions that prevent you from writing the spec:
    a. Post a comment on the issue with your questions: `gh issue comment {number} -R {owner}/{repo} --body "## Questions\n\n..."`
-   b. Call `advance_to_blocked(reason)` with your questions.
+   b. Call `advance_to_blocked()` with your questions.
 5. Write the spec and post it as a comment on the issue:
    `gh issue comment {number} -R {owner}/{repo} --body "## Spec\n\n..."`
 6. Call `advance_to_in_progress()` to trigger implementation.
@@ -30,7 +30,7 @@ Your spec comment should include:
 ## State Advancement (REQUIRED)
 You have MCP tools to signal state transitions to AutoDev. You MUST call exactly one before finishing:
 
-- `advance_to_blocked(reason)`: Call this when you have blocking questions that prevent you from writing the spec. Provide the specific questions as the reason. AutoDev will notify the user.
+- `advance_to_blocked()`: Call this when you have blocking questions that prevent you from writing the spec. AutoDev will notify the user.
 - `advance_to_in_progress()`: Call this AFTER you have written and posted the spec comment. This signals that spec is complete and implementation should begin automatically.
 
 IMPORTANT: Always call one of these tools as your final action. If you posted questions → call `advance_to_blocked`. If you posted a spec → call `advance_to_in_progress`.

--- a/src-tauri/src/bin/autodev_mcp.rs
+++ b/src-tauri/src/bin/autodev_mcp.rs
@@ -92,13 +92,8 @@ fn handle_request(request: &Value) -> Option<Value> {
                         "description": "Signal that this issue needs human input before the AI can proceed. Call this when you have blocking questions or need clarification from the user.",
                         "inputSchema": {
                             "type": "object",
-                            "properties": {
-                                "reason": {
-                                    "type": "string",
-                                    "description": "The specific questions or blockers that need human input"
-                                }
-                            },
-                            "required": ["reason"]
+                            "properties": {},
+                            "required": []
                         }
                     },
                     {

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -12,7 +12,7 @@ use crate::types::*;
 /// A state transition signal from the AI via MCP tools.
 #[derive(Debug, Clone)]
 pub enum StateSignal {
-    AdvanceToBlocked { reason: String },
+    AdvanceToBlocked,
     AdvanceToInProgress,
     AdvanceToReview,
 }
@@ -57,7 +57,7 @@ pub fn detect_signal_from_json(json: &Value) -> Option<StateSignal> {
     None
 }
 
-fn parse_tool_name_and_input(name: Option<&str>, input: Option<&Value>) -> Option<StateSignal> {
+fn parse_tool_name_and_input(name: Option<&str>, _input: Option<&Value>) -> Option<StateSignal> {
     let name = name?;
     // Strip mcp__autodev__ prefix if present
     let tool = name
@@ -65,14 +65,7 @@ fn parse_tool_name_and_input(name: Option<&str>, input: Option<&Value>) -> Optio
         .unwrap_or(name);
 
     match tool {
-        "advance_to_blocked" => {
-            let reason = input
-                .and_then(|i| i.get("reason"))
-                .and_then(|r| r.as_str())
-                .unwrap_or("Blocked — awaiting human input")
-                .to_string();
-            Some(StateSignal::AdvanceToBlocked { reason })
-        }
+        "advance_to_blocked" => Some(StateSignal::AdvanceToBlocked),
         "advance_to_in_progress" => Some(StateSignal::AdvanceToInProgress),
         "advance_to_review" => Some(StateSignal::AdvanceToReview),
         _ => None,

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -273,17 +273,10 @@ pub async fn session_start(
                         );
                         auto_start_implement(&app, spec_repo_id, spec_issue_number).await;
                     }
-                    Some(provider::StateSignal::AdvanceToBlocked { ref reason }) => {
+                    Some(provider::StateSignal::AdvanceToBlocked) => {
                         // Spec needs human input
                         update_status_via_app(&app, session_db_id, "completed", None);
                         set_issue_column_via_app(&app, spec_repo_id, spec_issue_number, "blocked");
-                        let _ = app.emit(
-                            "session-blocked",
-                            serde_json::json!({
-                                "session_id": session_db_id.to_string(),
-                                "question": reason,
-                            }),
-                        );
                     }
                     _ => {
                         // No signal — just mark completed
@@ -747,17 +740,10 @@ pub async fn session_respond(
                         update_status_via_app(&app, session_db_id, "completed", None);
                         set_issue_column_via_app(&app, respond_repo_id, respond_issue_number, "review");
                     }
-                    Some(provider::StateSignal::AdvanceToBlocked { ref reason }) => {
+                    Some(provider::StateSignal::AdvanceToBlocked) => {
                         // Still blocked — need more input
                         update_status_via_app(&app, session_db_id, "completed", None);
                         set_issue_column_via_app(&app, respond_repo_id, respond_issue_number, "blocked");
-                        let _ = app.emit(
-                            "session-blocked",
-                            serde_json::json!({
-                                "session_id": session_db_id.to_string(),
-                                "question": reason,
-                            }),
-                        );
                     }
                     _ => {
                         update_status_via_app(&app, session_db_id, "completed", None);
@@ -1238,16 +1224,9 @@ async fn handle_implement_result(
                         },
                     );
                 }
-                Some(provider::StateSignal::AdvanceToBlocked { ref reason }) => {
+                Some(provider::StateSignal::AdvanceToBlocked) => {
                     update_status_via_app(app, session_db_id, "completed", None);
                     set_issue_column_via_app(app, repo_id, issue_number, "blocked");
-                    let _ = app.emit(
-                        "session-blocked",
-                        serde_json::json!({
-                            "session_id": session_db_id.to_string(),
-                            "question": reason,
-                        }),
-                    );
                 }
                 _ => {
                     // No signal — just mark completed and advance to review by default

--- a/src/lib/stores/backend.ts
+++ b/src/lib/stores/backend.ts
@@ -71,21 +71,6 @@ export async function initBackend() {
 		});
 	});
 
-	await listen<{ session_id: string; question: string }>('session-blocked', (event) => {
-		sessionLogs.update((current) => {
-			const logs = current.get(event.payload.session_id) ?? [];
-			logs.push({
-				id: crypto.randomUUID(),
-				session_id: event.payload.session_id,
-				timestamp: new Date().toISOString(),
-				event_type: 'message',
-				content: event.payload.question
-			});
-			current.set(event.payload.session_id, logs);
-			return new Map(current);
-		});
-	});
-
 	await listen<{ session_id: string; error: string }>('session-error', (event) => {
 		sessionLogs.update((current) => {
 			const logs = current.get(event.payload.session_id) ?? [];


### PR DESCRIPTION
## Summary
- Removes the `reason` parameter from the `advance_to_blocked` MCP tool, the `StateSignal` enum, session handlers, and agent prompts
- Removes the `session-blocked` frontend event listener that injected a duplicate log entry
- The agent's questions are already visible in the session conversation, so the separate reason was redundant

## Test plan
- [ ] Verify `advance_to_blocked()` works without arguments during spec/implement/review
- [ ] Confirm blocked issues still move to the blocked column on the kanban board
- [ ] Verify no duplicate log entry appears in the session logs when an issue is blocked